### PR TITLE
Added "nvidia_backlight" to the list of backlight interfaces.

### DIFF
--- a/src/gpm-backlight-helper.c
+++ b/src/gpm-backlight-helper.c
@@ -52,6 +52,7 @@ gcm_backlight_helper_get_best_backlight ()
 	/* available kernel interfaces in priority order */
 	static const gchar *backlight_interfaces[] = {
 		"nv_backlight",
+		"nvidia_backlight",
 		"asus_laptop",
 		"toshiba",
 		"eeepc",


### PR DESCRIPTION
Setting brightness with hotkeys should now work on notebooks with the Nvidia binary driver (tested on MacBook Pro 7,1).
