### PR TITLE
Corrects an issue with deprecated glib apis

### DIFF
--- a/src/gpm-main.c
+++ b/src/gpm-main.c
@@ -183,8 +183,11 @@ main (int argc, char *argv[])
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 
+#if GLIB_CHECK_VERSION(2,32,0)    
+#else
 	if (! g_thread_supported ())
 		g_thread_init (NULL);
+#endif
 	dbus_g_thread_init ();
 	g_type_init ();
 
@@ -200,8 +203,11 @@ main (int argc, char *argv[])
 		goto unref_program;
 	}
 
+#if GLIB_CHECK_VERSION(2,32,0)    
+#else
 	if (!g_thread_supported ())
 		g_thread_init (NULL);
+#endif
 	dbus_g_thread_init ();
 
 	gtk_init (&argc, &argv);

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1564,8 +1564,11 @@ main (int argc, char *argv[])
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 
+#if GLIB_CHECK_VERSION(2,32,0)    
+#else
 	if (! g_thread_supported ())
 		g_thread_init (NULL);
+#endif
 	dbus_g_thread_init ();
 	g_type_init ();
 


### PR DESCRIPTION
This adds checks for glib version, in regards to deprecated apis. see http://developer.gnome.org/glib/2.31/glib-Deprecated-Thread-APIs.html#g-thread-init
