### PR TITLE
Screen on dim, will not "undim" 

### DIFF
--- a/src/gpm-idle.c
+++ b/src/gpm-idle.c
@@ -352,7 +352,7 @@ static void
 gpm_idle_session_idle_changed_cb (GpmSession *session, gboolean is_idle, GpmIdle *idle)
 {
 	egg_debug ("Received mate session idle changed: %i", is_idle);
-	idle->priv->x_idle = TRUE;
+	idle->priv->x_idle = is_idle;
 	gpm_idle_evaluate (idle);
 }
 


### PR DESCRIPTION
This was a mistake I introduced with my former fix to idle behaviour correction. After a number of days running this I noticed the issue. This corrects the bug, and as a precaution, I have run this patch for a number of days to ensure that it does not affect other system components (Unlike last time)
