### PR TITLE
Systemd inhibit support for MPM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,6 +270,25 @@ AC_MSG_RESULT([$have_applets])
 AM_CONDITIONAL([HAVE_APPLETS], [test $have_applets = yes])
 
 dnl ---------------------------------------------------------------------------
+dnl systemd inhibit
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_WITH(systemdinhibit,
+            AS_HELP_STRING([--with-systemdinhibit],
+            [Add systemdinhibit support]),,
+            with_systemdinhibit=auto)
+
+use_systemdinhibit=no
+if test "x$with_systemdinhibit" != "xno" ; then
+    use_systemdinhibit=yes
+    AC_DEFINE(WITH_SYSTEMD_INHIBIT, 1, [systemdinhibit support])
+
+    PKG_CHECK_MODULES(SYSTEMD_INHIBIT, libsystemd-login libsystemd-daemon)
+fi
+AM_CONDITIONAL(WITH_SYSTEMD_INHIBIT, test x$use_systemdinhibit = xyes)
+AC_SUBST(WITH_SYSTEMD_INHIBIT)
+
+dnl ---------------------------------------------------------------------------
 dnl - DocBook Documentation
 dnl ---------------------------------------------------------------------------
 AC_ARG_ENABLE(docbook-docs,
@@ -382,6 +401,7 @@ echo "
         Building extra applets:    ${enable_applets}
         Self test support:         ${have_tests}
         Use libunique:             ${enable_libunique}
+        systemd support:           ${use_systemdinhibit}
         Docbook support:           ${enable_docbook_docs}
         documentation dir:         $DOCDIR
         dbus-1 services dir:       $DBUS_SERVICES_DIR

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -1842,6 +1842,7 @@ gpm_manager_control_resume_cb (GpmControl *control, GpmControlAction action, Gpm
 	g_timeout_add_seconds (1, gpm_manager_reset_just_resumed_cb, manager);
 }
 
+#ifdef WITH_SYSTEMD_INHIBIT
 /**
  * gpm_main_system_inhibit:
  **/
@@ -1909,6 +1910,7 @@ gpm_manager_systemd_inhibit (GDBusProxy *proxy) {
     egg_debug ("Inhibiting systemd sleep - success");
     return r;
 }
+#endif
 
 /**
  * gpm_manager_init:
@@ -1927,8 +1929,10 @@ gpm_manager_init (GpmManager *manager)
 	connection = dbus_g_bus_get (DBUS_BUS_SESSION, &error);
     g_connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
 
+#ifdef WITH_SYSTEMD_INHIBIT
     /* We want to inhibit the systemd suspend options, and take care of them ourselves */
     manager->priv->systemd_inhibit = gpm_manager_systemd_inhibit (manager->priv->systemd_inhibit_proxy);
+#endif
 
 	/* init to unthrottled */
 	manager->priv->screensaver_ac_throttle_id = 0;
@@ -2087,6 +2091,7 @@ gpm_manager_finalize (GObject *object)
 	g_object_unref (manager->priv->client);
 	g_object_unref (manager->priv->status_icon);
 
+#ifdef WITH_SYSTEMD_INHIBIT
     /* Let systemd take over again ... */
     if (manager->priv->systemd_inhibit > 0) {
         close(manager->priv->systemd_inhibit);
@@ -2095,6 +2100,7 @@ gpm_manager_finalize (GObject *object)
         g_object_unref (manager->priv->systemd_inhibit_proxy);
     }
     //g_object_unref (manager->priv->systemd_inhibit);
+#endif
 
 	G_OBJECT_CLASS (gpm_manager_parent_class)->finalize (object);
 }


### PR DESCRIPTION
This pull enables systemd-inihibt support. For the moment, we disable and inhibit all actions regarding special keys, and allow shutdown, suspend and restart to still be initiated from systemd. For example, closing a laptop lid will now suspend only once, as the keyswitch action is blocked from systemd.

This patch is largely untested at this time, and relies heavily on systemd to respect our request. Initial tests of power button actions and the like show correct behaviour. I will test this more over the coming few days, but it would be good for others to test it also. 
