### PR TITLE
Auto-detect whether to build systemd support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,10 +280,12 @@ AC_ARG_WITH(systemdinhibit,
 
 use_systemdinhibit=no
 if test "x$with_systemdinhibit" != "xno" ; then
-    use_systemdinhibit=yes
-    AC_DEFINE(WITH_SYSTEMD_INHIBIT, 1, [systemdinhibit support])
+    PKG_CHECK_MODULES(SYSTEMD_INHIBIT, libsystemd-login libsystemd-daemon, use_systemdinhibit=yes, use_systemdinhibit=no)
 
-    PKG_CHECK_MODULES(SYSTEMD_INHIBIT, libsystemd-login libsystemd-daemon)
+    if test "x$use_systemdinhibit" = "xyes"; then
+        AC_DEFINE(WITH_SYSTEMD_INHIBIT, 1, [systemdinhibit support])
+    fi
+
 fi
 AM_CONDITIONAL(WITH_SYSTEMD_INHIBIT, test x$use_systemdinhibit = xyes)
 AC_SUBST(WITH_SYSTEMD_INHIBIT)

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -100,8 +100,10 @@ struct GpmManagerPrivate
 	NotifyNotification	*notification_warning_low;
 	NotifyNotification	*notification_discharging;
 	NotifyNotification	*notification_fully_charged;
-    gint32              systemd_inhibit;
-    GDBusProxy          *systemd_inhibit_proxy;
+#ifdef WITH_SYSTEMD_INHIBIT
+	gint32                   systemd_inhibit;
+	GDBusProxy              *systemd_inhibit_proxy;
+#endif
 };
 
 typedef enum {


### PR DESCRIPTION
This uses the result of PKG_CHECK_MODULES to determine whether to build systemd inhibit support.
