### PR TITLE
Added systemd version check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,7 +280,7 @@ AC_ARG_WITH(systemdinhibit,
 
 use_systemdinhibit=no
 if test "x$with_systemdinhibit" != "xno" ; then
-    PKG_CHECK_MODULES(SYSTEMD_INHIBIT, libsystemd-login libsystemd-daemon, use_systemdinhibit=yes, use_systemdinhibit=no)
+    PKG_CHECK_MODULES(SYSTEMD_INHIBIT, libsystemd-login >= 195 libsystemd-daemon >= 195 , use_systemdinhibit=yes, use_systemdinhibit=no)
 
     if test "x$use_systemdinhibit" = "xyes"; then
         AC_DEFINE(WITH_SYSTEMD_INHIBIT, 1, [systemdinhibit support])


### PR DESCRIPTION
A user enabled systemd-inhibit on a system with systemd < 195. This caused mate-power-manager to crash. This check makes sure that we have at least system 195, which is the first version that requires inhibit / logind support.
