### PR TITLE
Make mate-keyring support optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,6 @@ PKG_CHECK_MODULES(DBUS,[
 
 PKG_CHECK_MODULES(MATE, [
  gtk+-2.0 >= $GTK_REQUIRED
- mate-keyring-1 >= $MATE_KEYRING_REQUIRED
  cairo >= $CAIRO_REQUIRED])
 
 PKG_CHECK_MODULES(GDK, [
@@ -249,6 +248,22 @@ else
     AC_MSG_RESULT(no)
 fi
 AM_CONDITIONAL([HAVE_TESTS], [test $have_tests = yes])
+
+dnl ---------------------------------------------------------------------------
+dnl - Build mate-keyring support
+dnl ---------------------------------------------------------------------------
+AC_ARG_WITH(keyring,
+        [AS_HELP_STRING([--without-keyring],
+                        [Disable the use of mate-keyring])],
+        [],
+        [with_keyring=yes])
+
+AM_CONDITIONAL([WITH_KEYRING],[test "$with_keyring" = "yes"])
+
+if test "$with_keyring" = "yes"; then
+        PKG_CHECK_MODULES(KEYRING, mate-keyring-1 >= $MATE_KEYRING_REQUIRED)
+        AC_DEFINE([WITH_KEYRING],[1],[Define if KEYRING support is enabled])
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl - Build applets
@@ -400,6 +415,7 @@ echo "
         datadir:                   ${datadir}
         compiler:                  ${CC}
         cflags:                    ${CFLAGS}
+        mate-keyring support:      ${with_keyring}
         Building extra applets:    ${enable_applets}
         Self test support:         ${have_tests}
         Use libunique:             ${enable_libunique}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,7 @@ INCLUDES =						\
 	$(GLIB_CFLAGS)					\
 	$(DBUS_CFLAGS)					\
 	$(MATE_CFLAGS)					\
+	$(KEYRING_CFLAGS)				\
 	$(UNIQUE_CFLAGS)				\
 	$(X11_CFLAGS)					\
 	$(LIBMATENOTIFY_CFLAGS)				\
@@ -184,6 +185,7 @@ mate_power_manager_LDADD =				\
 	$(X11_LIBS)				\
 	$(GSTREAMER_LIBS)				\
 	$(MATE_LIBS)					\
+	$(KEYRING_LIBS)					\
 	$(DBUS_LIBS)					\
 	$(X11_LIBS)						\
 	$(CANBERRA_LIBS)				\
@@ -250,6 +252,7 @@ mate_power_self_test_LDADD =				\
 	$(GLIB_LIBS)					\
 	$(X11_LIBS)					\
 	$(MATE_LIBS)					\
+	$(KEYRING_LIBS)					\
 	$(GSTREAMER_LIBS)				\
 	$(UPOWER_LIBS)					\
 	$(DBUS_LIBS)					\

--- a/src/gpm-control.c
+++ b/src/gpm-control.c
@@ -39,8 +39,11 @@
 #include <glib/gi18n.h>
 #include <dbus/dbus-glib.h>
 #include <dbus/dbus-glib-lowlevel.h>
-#include <mate-keyring.h>
 #include <libupower-glib/upower.h>
+
+#ifdef WITH_KEYRING
+#include <mate-keyring.h>
+#endif /* WITH_KEYRING */
 
 #include "egg-debug.h"
 #include "egg-console-kit.h"
@@ -157,10 +160,12 @@ gpm_control_suspend (GpmControl *control, GError **error)
 	gboolean ret = FALSE;
 	gboolean do_lock;
 	gboolean nm_sleep;
-	gboolean lock_mate_keyring;
-	MateKeyringResult keyres;
 	GpmScreensaver *screensaver;
 	guint32 throttle_cookie = 0;
+#ifdef WITH_KEYRING
+	gboolean lock_mate_keyring;
+	MateKeyringResult keyres;
+#endif /* WITH_KEYRING */
 
 	screensaver = gpm_screensaver_new ();
 
@@ -173,6 +178,7 @@ gpm_control_suspend (GpmControl *control, GError **error)
 		goto out;
 	}
 
+#ifdef WITH_KEYRING
 	/* we should perhaps lock keyrings when sleeping #375681 */
 	lock_mate_keyring = g_settings_get_boolean (control->priv->settings, GPM_SETTINGS_LOCK_KEYRING_SUSPEND);
 	if (lock_mate_keyring) {
@@ -180,6 +186,7 @@ gpm_control_suspend (GpmControl *control, GError **error)
 		if (keyres != MATE_KEYRING_RESULT_OK)
 			egg_warning ("could not lock keyring");
 	}
+#endif /* WITH_KEYRING */
 
 	do_lock = gpm_control_get_lock_policy (control, GPM_SETTINGS_LOCK_ON_SUSPEND);
 	if (do_lock) {
@@ -225,10 +232,12 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 	gboolean ret = FALSE;
 	gboolean do_lock;
 	gboolean nm_sleep;
-	gboolean lock_mate_keyring;
-	MateKeyringResult keyres;
 	GpmScreensaver *screensaver;
 	guint32 throttle_cookie = 0;
+#ifdef WITH_KEYRING
+	gboolean lock_mate_keyring;
+	MateKeyringResult keyres;
+#endif /* WITH_KEYRING */
 
 	screensaver = gpm_screensaver_new ();
 
@@ -241,6 +250,7 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 		goto out;
 	}
 
+#ifdef WITH_KEYRING
 	/* we should perhaps lock keyrings when sleeping #375681 */
 	lock_mate_keyring = g_settings_get_boolean (control->priv->settings, GPM_SETTINGS_LOCK_KEYRING_HIBERNATE);
 	if (lock_mate_keyring) {
@@ -249,6 +259,7 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 			egg_warning ("could not lock keyring");
 		}
 	}
+#endif /* WITH_KEYRING */
 
 	do_lock = gpm_control_get_lock_policy (control, GPM_SETTINGS_LOCK_ON_HIBERNATE);
 	if (do_lock) {


### PR DESCRIPTION
This patch allows building mate-power-manager without libmatekeyring, similar to Atril. (--without-keyring)
