### PR TITLE
Treat 'cahallenge' responce as 'yes'

### DIFF
--- a/src/gpm-control.c
+++ b/src/gpm-control.c
@@ -225,7 +225,7 @@ gpm_control_suspend (GpmControl *control, GError **error)
         return -1;
     }
     g_dbus_proxy_call_sync (proxy, "Suspend", 
-                            g_variant_new( "(b)",FALSE),
+                            g_variant_new( "(b)",gpm_button_get_lid_closed()==TRUE?FALSE:TRUE),
                             G_DBUS_CALL_FLAGS_NONE,
                             -1,
                             NULL,
@@ -339,7 +339,7 @@ gpm_control_hibernate (GpmControl *control, GError **error)
         return -1;
     }
     g_dbus_proxy_call_sync (proxy, "Hibernate", 
-                            g_variant_new( "(b)",FALSE),
+                            g_variant_new( "(b)",gpm_button_get_lid_closed()==TRUE?FALSE:TRUE),
                             G_DBUS_CALL_FLAGS_NONE,
                             -1,
                             NULL,

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -855,7 +855,7 @@ gpm_prefs_init (GpmPrefs *prefs)
                             );
     if (error == NULL && res != NULL) {
         g_variant_get(res,"(s)", &r);
-	prefs->priv->can_suspend = g_strcmp0(r,"yes")==0?TRUE:FALSE;
+	prefs->priv->can_suspend = (g_strcmp0(r,"yes")==0 || g_strcmp0(r,"challenge")==0)?TRUE:FALSE;
 	g_variant_unref (res);
     } else if (error != NULL ) {
 	    egg_error ("Error in dbus - %s", error->message);
@@ -871,7 +871,7 @@ gpm_prefs_init (GpmPrefs *prefs)
                             );
     if (error == NULL && res != NULL) {
         g_variant_get(res,"(s)", &r);
-	prefs->priv->can_hibernate = g_strcmp0(r,"yes")==0?TRUE:FALSE;
+	prefs->priv->can_hibernate = (g_strcmp0(r,"yes")==0 || g_strcmp0(r,"challenge")==0)?TRUE:FALSE;
 	g_variant_unref (res);
     } else if (error != NULL ) {
 	    egg_error ("Error in dbus - %s", error->message);


### PR DESCRIPTION
'challenge' responce means that hardware able to suspend/hibernate,
so we should show this ability in preferences dialog.
Suspending/hibernation, then can produce an authorisation dialog
unless lid is closed.