### PR TITLE
Add DBUS interface to kbdbacklight control

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,7 @@ NULL =
 EXTRA_DIST =						\
 	org.mate.PowerManager.xml			\
 	org.mate.PowerManager.Backlight.xml		\
+	org.mate.PowerManager.KbdBacklight.xml		\
 	gpm-marshal.list				\
 	$(NULL)
 
@@ -271,6 +272,7 @@ endif
 BUILT_SOURCES = 					\
 	org.mate.PowerManager.h			\
 	org.mate.PowerManager.Backlight.h		\
+	org.mate.PowerManager.KbdBacklight.h \
 	gpm-marshal.c					\
 	gpm-marshal.h					\
 	$(NULL)
@@ -295,6 +297,13 @@ org.mate.PowerManager.Backlight.h: org.mate.PowerManager.Backlight.xml
 		--mode=glib-server			\
 		--output=org.mate.PowerManager.Backlight.h	\
 		$(srcdir)/org.mate.PowerManager.Backlight.xml
+
+org.mate.PowerManager.KbdBacklight.h: org.mate.PowerManager.KbdBacklight.xml
+	libtool --mode=execute dbus-binding-tool	\
+		--prefix=gpm_kbd_backlight			\
+		--mode=glib-server			\
+		--output=org.mate.PowerManager.KbdBacklight.h	\
+		$(srcdir)/org.mate.PowerManager.KbdBacklight.xml
 
 clean-local:
 	rm -f *~

--- a/src/gpm-common.h
+++ b/src/gpm-common.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 #define	GPM_DBUS_SERVICE		"org.mate.PowerManager"
 #define	GPM_DBUS_INTERFACE		"org.mate.PowerManager"
 #define	GPM_DBUS_INTERFACE_BACKLIGHT	"org.mate.PowerManager.Backlight"
+#define	GPM_DBUS_INTERFACE_KBD_BACKLIGHT	"org.mate.PowerManager.KbdBacklight"
 #define	GPM_DBUS_PATH			"/org/mate/PowerManager"
 #define	GPM_DBUS_PATH_BACKLIGHT		"/org/mate/PowerManager/Backlight"
 #define GPM_DBUS_PATH_KBD_BACKLIGHT    "/org/mate/PowerManager/KbdBacklight"

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -31,21 +31,6 @@
 #include "gpm-kbd-backlight.h"
 #include "gsd-media-keys-window.h"
 
-static const gchar *kbd_backlight_introspection = ""
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>""<node name=\"/\">"
-  "<interface name=\"org.mate.PowerManager.Backlight\">"
-    "<method name=\"GetBrightness\">"
-      "<arg type=\"u\" name=\"percentage_brightness\" direction=\"out\"/>"
-    "</method>"
-    "<method name=\"SetBrightness\">"
-      "<arg type=\"u\" name=\"percentage_brightness\" direction=\"in\"/>"
-    "</method>"
-    "<signal name=\"BrightnessChanged\">"
-      "<arg type=\"u\" name=\"percentage_brightness\" direction=\"out\"/>"
-    "</signal>"
-  "</interface>"
-"</node>";
-
 #define GPM_KBD_BACKLIGHT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GPM_TYPE_KBD_BACKLIGHT, GpmKbdBacklightPrivate))
 
 struct GpmKbdBacklightPrivate
@@ -428,40 +413,6 @@ gpm_kbd_backlight_dbus_property_set (GDBusConnection *connection,
 {
    /* do nothing, no properties defined */
    return FALSE;
-}
-
-/**
- * gpm_kbd_backlight_register_dbus:
- * @backlight:
- * @connection:
- * @error:
- **/
-void
-gpm_kbd_backlight_register_dbus (GpmKbdBacklight *backlight,
-                GDBusConnection *connection,
-                GError **error)
-{
-   GDBusNodeInfo *node_info;
-   GDBusInterfaceInfo *interface_info;
-   GDBusInterfaceVTable interface_vtable = {
-           gpm_kbd_backlight_dbus_method_call,
-           gpm_kbd_backlight_dbus_property_get,
-           gpm_kbd_backlight_dbus_property_set
-   };
-
-   node_info = g_dbus_node_info_new_for_xml (kbd_backlight_introspection, NULL);
-   interface_info = g_dbus_node_info_lookup_interface (node_info, GPM_DBUS_INTERFACE_BACKLIGHT);
-
-   backlight->priv->bus_connection = g_object_ref (connection);
-   backlight->priv->bus_object_id =
-       g_dbus_connection_register_object (connection,
-                          GPM_DBUS_PATH_KBD_BACKLIGHT,
-                          interface_info,
-                          &interface_vtable,
-                          backlight,
-                          NULL,
-                          error);
-   g_dbus_node_info_unref (node_info);
 }
 
 static gboolean

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -65,6 +65,7 @@
 #include "gpm-disks.h"
 
 #include "org.mate.PowerManager.Backlight.h"
+#include "org.mate.PowerManager.KbdBacklight.h"
 
 static void     gpm_manager_finalize	(GObject	 *object);
 
@@ -1997,9 +1998,11 @@ gpm_manager_init (GpmManager *manager)
 
     manager->priv->kbd_backlight = gpm_kbd_backlight_new ();
     if (manager->priv->kbd_backlight != NULL) {
-        gpm_kbd_backlight_register_dbus (manager->priv->kbd_backlight,
-                                        g_connection,
-                                        NULL);
+    	dbus_g_object_type_install_info (GPM_TYPE_KBD_BACKLIGHT,
+						 &dbus_glib_gpm_kbd_backlight_object_info);
+		dbus_g_connection_register_g_object (connection, GPM_DBUS_PATH_KBD_BACKLIGHT,
+						     G_OBJECT (manager->priv->kbd_backlight));
+    
     }
 
 	manager->priv->idle = gpm_idle_new ();

--- a/src/org.mate.PowerManager.KbdBacklight.xml
+++ b/src/org.mate.PowerManager.KbdBacklight.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<node name="/">
+  <interface name="org.mate.PowerManager.KbdBacklight">
+    <method name="GetBrightness">
+      <arg type="u" name="percentage_brightness" direction="out"/>
+    </method>
+    <method name="SetBrightness">
+      <arg type="u" name="percentage_brightness" direction="in"/>
+    </method>
+    <signal name="BrightnessChanged">
+      <arg type="u" name="percentage_brightness" direction="out"/>
+    </signal>
+  </interface>
+</node>
+


### PR DESCRIPTION
This adds control via dbus for manipulation of the kbdbacklight. Please see http://koji.fedoraproject.org/koji/taskinfo?taskID=5547176 and http://koji.fedoraproject.org/koji/taskinfo?taskID=5547179 . 
