### PR TITLE
fix typo in gpm_control_suspend, gpm-control.c

### DIFF
--- a/src/gpm-control.c
+++ b/src/gpm-control.c
@@ -221,7 +221,7 @@ gpm_control_suspend (GpmControl *control, GError **error)
 
 	screensaver = gpm_screensaver_new ();
 
-	if (LOGIND_RUNNING()) {
+	if (!LOGIND_RUNNING()) {
 		g_object_get (control->priv->client,
 			      "can-suspend", &allowed,
 			      NULL);


### PR DESCRIPTION
this fixed 'suspend on lid close'
https://bugzilla.redhat.com/show_bug.cgi?id=1012718
