### PR TITLE
Reverse configure logic for --enable-deprecated

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,17 +49,8 @@ AC_ARG_ENABLE(deprecated,
                 [Warn about deprecated usages [default=no]])],,
          [enable_deprecated=no])
 
-if test "x$enable_deprecated" = "xno"; then
-	DISABLE_DEPRECATED=" \
-	-DG_DISABLE_SINGLE_INCLUDES \
-	-DGTK_DISABLE_SINGLE_INCLUDES \
-	-DG_DISABLE_DEPRECATED \
-	-DGTK_DISABLE_DEPRECATED \
-	-DGDK_DISABLE_DEPRECATED \
-	-DGDK_MULTIHEAD_SAFE \
-	-DGTK_MULTIHEAD_SAFE \
-	-DGSEAL_ENABLE"
-
+if test "x$enable_deprecated" = "xyes"; then
+	DISABLE_DEPRECATED=""
 	CPPFLAGS="$CPPFLAGS $DISABLE_DEPRECATED"
 fi
 


### PR DESCRIPTION
And just set DISABLE_DEPRECATED to an empty string.

There is no need to add these flags as they are already included when using --enable-strict. So just reverse the logic and if one wants more warnings they can use that config option.
