### PR TITLE
move applets and ui files to mate-panel dirs

### DIFF
--- a/applets/brightness/Makefile.am
+++ b/applets/brightness/Makefile.am
@@ -61,7 +61,7 @@ org.mate.panel.applet.BrightnessAppletFactory.service: $(service_in_files)
             -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
             $< > $@
 
-uidir   = $(datadir)/mate-2.0/ui
+uidir   = $(datadir)/mate-panel/ui
 ui_DATA = brightness-applet-menu.xml
 
 EXTRA_DIST = org.mate.BrightnessApplet.mate-panel-applet.in.in $(ui_DATA) $(service_in_files)

--- a/applets/inhibit/Makefile.am
+++ b/applets/inhibit/Makefile.am
@@ -60,7 +60,7 @@ org.mate.panel.applet.InhibitAppletFactory.service: $(service_in_files)
             -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
             $< > $@
 
-uidir   = $(datadir)/mate-2.0/ui
+uidir   = $(datadir)/mate-panel/ui
 ui_DATA = inhibit-applet-menu.xml
 
 EXTRA_DIST = org.mate.InhibitApplet.mate-panel-applet.in.in $(ui_DATA) $(service_in_files)


### PR DESCRIPTION
this simplifies packaging, no other package uses mate-2.0 dir, and this applet fits to "mate-panel" dir nicely like other applets. i've been using this patch since 1.6 with no problems
