### PR TITLE
correctly call cairo_destroy

### DIFF
--- a/src/gpm-graph-widget.c
+++ b/src/gpm-graph-widget.c
@@ -1184,7 +1184,7 @@ gpm_graph_widget_expose (GtkWidget *graph, GdkEventExpose *event)
 
 	gpm_graph_widget_draw_graph (graph, cr);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	cairo_destroy (cr);
 #endif
 	return FALSE;


### PR DESCRIPTION
fix memory leak with gtk2 runtime
cairo assertion with gtk3
