### PR TITLE
statistics: adjustment for API breakage in upower 0.99

### DIFF
--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1183,16 +1183,47 @@ gpm_stats_window_activated_cb (EggUnique *egg_unique, gpointer data)
 }
 
 /**
+ * gpm_stats_device_changed_cb:
+ **/
+static void
+#if UP_CHECK_VERSION(0, 99, 0)
+gpm_stats_device_changed_cb (UpDevice *device, GParamSpec *pspec, gpointer user_data)
+#else
+gpm_stats_device_changed_cb (UpClient *client, UpDevice *device, gpointer user_data)
+#endif
+{
+	const gchar *object_path;
+	object_path = up_device_get_object_path (device);
+	if (object_path == NULL || current_device == NULL)
+		return;
+	egg_debug ("changed:   %s", object_path);
+	if (g_strcmp0 (current_device, object_path) == 0)
+		gpm_stats_update_info_data (device);
+}
+
+/**
  * gpm_stats_add_device:
  **/
 static void
+#if UP_CHECK_VERSION(0, 99, 0)
+gpm_stats_add_device (UpDevice *device, GPtrArray *devices)
+#else
 gpm_stats_add_device (UpDevice *device)
+#endif
 {
 	const gchar *id;
 	GtkTreeIter iter;
 	const gchar *text;
 	const gchar *icon;
 	UpDeviceKind kind;
+
+#if UP_CHECK_VERSION(0, 99, 0)
+	if (devices != NULL)
+		g_ptr_array_add (devices, device);
+
+	g_signal_connect (device, "notify",
+	                  G_CALLBACK (gpm_stats_device_changed_cb), NULL);
+#endif
 
 	/* get device properties */
 	g_object_get (device,
@@ -1224,48 +1255,51 @@ gpm_stats_data_changed_cb (UpClient *client, gpointer user_data)
  * gpm_stats_device_added_cb:
  **/
 static void
+#if UP_CHECK_VERSION(0, 99, 0)
+gpm_stats_device_added_cb (UpClient *client, UpDevice *device, GPtrArray *devices)
+#else
 gpm_stats_device_added_cb (UpClient *client, UpDevice *device, gpointer user_data)
+#endif
 {
 	const gchar *object_path;
 	object_path = up_device_get_object_path (device);
 	egg_debug ("added:     %s", object_path);
-	gpm_stats_add_device (device);
-}
 
-/**
- * gpm_stats_device_changed_cb:
- **/
-static void
 #if UP_CHECK_VERSION(0, 99, 0)
-gpm_stats_device_changed_cb (UpClient *client, GParamSpec *pspec, gpointer user_data)
-{
-	gpm_stats_button_update_ui();
-}
+	gpm_stats_add_device (device, devices);
 #else
-gpm_stats_device_changed_cb (UpClient *client, UpDevice *device, gpointer user_data)
-{
-	const gchar *object_path;
-	object_path = up_device_get_object_path (device);
-	if (object_path == NULL || current_device == NULL)
-		return;
-	egg_debug ("changed:   %s", object_path);
-	if (g_strcmp0 (current_device, object_path) == 0)
-		gpm_stats_update_info_data (device);
-}
+	gpm_stats_add_device (device);
 #endif
+}
 
 /**
  * gpm_stats_device_removed_cb:
  **/
 static void
+#if UP_CHECK_VERSION(0, 99, 0)
+gpm_stats_device_removed_cb (UpClient *client, const gchar *object_path, GPtrArray *devices)
+#else
 gpm_stats_device_removed_cb (UpClient *client, UpDevice *device, gpointer user_data)
+#endif
 {
-	const gchar *object_path;
 	GtkTreeIter iter;
 	gchar *id = NULL;
 	gboolean ret;
 
-	object_path = up_device_get_object_path (device);
+#if UP_CHECK_VERSION(0, 99, 0)
+	UpDevice *device_tmp;
+	guint i;
+
+	for (i = 0; i < devices->len; i++) {
+		device_tmp = g_ptr_array_index (devices, i);
+		if (g_strcmp0 (up_device_get_object_path (device_tmp), object_path) == 0) {
+			g_ptr_array_remove_index_fast (devices, i);
+			break;
+		}
+	}
+#else
+	const gchar *object_path = up_device_get_object_path (device);
+#endif
 	egg_debug ("removed:   %s", object_path);
 	if (g_strcmp0 (current_device, object_path) == 0) {
 		gtk_list_store_clear (list_store_info);
@@ -1520,7 +1554,7 @@ main (int argc, char *argv[])
 	EggUnique *egg_unique;
 	gboolean ret;
 	UpClient *client;
-	GPtrArray *devices;
+	GPtrArray *devices = NULL;
 	UpDevice *device;
 	UpDeviceKind kind;
 	guint i, j;
@@ -1752,16 +1786,24 @@ main (int argc, char *argv[])
 			device = g_ptr_array_index (devices, i);
 			g_object_get (device, "kind", &kind, NULL);
 			if (kind == j)
+#if UP_CHECK_VERSION(0, 99, 0)
+				/* NULL == do not add it to ptr array */
+				gpm_stats_add_device (device, NULL);
+#else
 				gpm_stats_add_device (device);
+#endif
 		}
 	}
 
 	/* connect now the coldplug is done */
+#if UP_CHECK_VERSION(0, 99, 0)
+	g_signal_connect (client, "device-added", G_CALLBACK (gpm_stats_device_added_cb), devices);
+	g_signal_connect (client, "device-removed", G_CALLBACK (gpm_stats_device_removed_cb), devices);
+#else
 	g_signal_connect (client, "device-added", G_CALLBACK (gpm_stats_device_added_cb), NULL);
 	g_signal_connect (client, "device-removed", G_CALLBACK (gpm_stats_device_removed_cb), NULL);
-#if UP_CHECK_VERSION(0, 99, 0)
-	g_signal_connect (client, "notify", G_CALLBACK (gpm_stats_device_changed_cb), NULL);
-#else
+#endif
+#if !UP_CHECK_VERSION(0, 99, 0)
 	g_signal_connect (client, "device-changed", G_CALLBACK (gpm_stats_device_changed_cb), NULL);
 #endif
 
@@ -1791,8 +1833,6 @@ main (int argc, char *argv[])
 	if (last_device != NULL)
 		gpm_stats_highlight_device (last_device);
 
-	g_ptr_array_unref (devices);
-
 	/* set axis */
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "combobox_history_type"));
 	gpm_stats_history_type_combo_changed_cb (widget, NULL);
@@ -1806,6 +1846,9 @@ main (int argc, char *argv[])
 #if !UP_CHECK_VERSION(0, 99, 0)
 out:
 #endif
+	if (devices != NULL)
+		g_ptr_array_unref (devices);
+
 	g_object_unref (settings);
 	g_object_unref (client);
 	g_object_unref (wakeups);


### PR DESCRIPTION
they've changed the argument type in the "device-removed" signal :-/

this might fix https://bugzilla.redhat.com/show_bug.cgi?id=1195898