### PR TITLE
Save copying cost

### DIFF
--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -712,9 +712,8 @@ gpm_prefs_init (GpmPrefs *prefs)
 					      &error
 					      );
 		if (error == NULL && res != NULL) {
-			g_variant_get(res,"(s)", &r);
+			g_variant_get(res,"(&s)", &r);
 			prefs->priv->can_shutdown = g_strcmp0(r,"yes")==0?TRUE:FALSE;
-			g_free(r);
 			g_variant_unref (res);
 		} else if (error != NULL ) {
 			egg_error ("Error in dbus - %s", error->message);
@@ -729,9 +728,8 @@ gpm_prefs_init (GpmPrefs *prefs)
 					      &error
 					      );
 		if (error == NULL && res != NULL) {
-			g_variant_get(res,"(s)", &r);
+			g_variant_get(res,"(&s)", &r);
 			prefs->priv->can_suspend = g_strcmp0(r,"yes")==0?TRUE:FALSE;
-			g_free(r);
 			g_variant_unref (res);
 		} else if (error != NULL ) {
 			egg_error ("Error in dbus - %s", error->message);
@@ -746,9 +744,8 @@ gpm_prefs_init (GpmPrefs *prefs)
 					      &error
 					      );
 		if (error == NULL && res != NULL) {
-			g_variant_get(res,"(s)", &r);
+			g_variant_get(res,"(&s)", &r);
 			prefs->priv->can_hibernate = g_strcmp0(r,"yes")==0?TRUE:FALSE;
-			g_free(r);
 			g_variant_unref (res);
 		} else if (error != NULL ) {
 			egg_error ("Error in dbus - %s", error->message);


### PR DESCRIPTION
Use '&' character in GVariant format string to save useless copies.