### PR TITLE
Support custom themes from panel

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -703,6 +703,19 @@ gpm_applet_create_popup (GpmBrightnessApplet *applet)
         g_signal_connect (G_OBJECT(applet->popup), "key-press-event",
                           G_CALLBACK(gpm_applet_key_press_cb), applet);
 #endif
+
+#if GTK_CHECK_VERSION (3, 0, 0) 
+	/* Set volume control frame, slider and toplevel window to follow panel volume control theme */ 
+	GtkWidget *toplevel = gtk_widget_get_toplevel (frame);
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
+	gtk_style_context_add_class(context,"mate-media-applet-slider");
+	/*Make transparency possible in gtk3 theme3 */   
+ 	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual);  
+#endif
 }
 
 /**

--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -333,6 +333,21 @@ gpm_tray_icon_create_menu (GpmTrayIcon *icon, guint32 timestamp)
 	g_signal_connect (G_OBJECT (item), "activate",
 			  G_CALLBACK (gpm_tray_icon_show_preferences_cb), icon);
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
+	
+	/*Set up custom panel menu theme support-gtk3 only */
+#if GTK_CHECK_VERSION (3, 0, 0) 
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency in menu theme */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+#endif
+
 
 	/* about */
 	item = gtk_image_menu_item_new_from_stock (GTK_STOCK_ABOUT, NULL);


### PR DESCRIPTION
Tray applet: Follow any custom menu theme set up for mate-panel with the .mate-panel-menu-bar .menu and/or .mate-panel-menu-bar .window-frame.csd.popup selectors

brightness applet: Follow any custom volume control theme set up using the .mate-media-applet-slider selector from the volume control applet in mate-media. Note that this slider is drawn inside a single frame while the volume control is drawn in a frame within a frame. This makes the volume control wider than the brightness slider.

Both commits use tabs for indent as the code around them also does. I attempted to follow the style around them as much as I could. This is from a newly made branch based on mate-desktop/master as of 10-13-2015.