### PR TITLE
Support disabling of PowerBtn.

### DIFF
--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -632,6 +632,7 @@ prefs_setup_general (GpmPrefs *prefs)
 				 GPM_ACTION_POLICY_SUSPEND,
 				 GPM_ACTION_POLICY_HIBERNATE,
 				 GPM_ACTION_POLICY_SHUTDOWN,
+				 GPM_ACTION_POLICY_NOTHING,
 				 -1};
 	const GpmActionPolicy suspend_button_actions[] =
 				{GPM_ACTION_POLICY_NOTHING,


### PR DESCRIPTION
 By adding GPM_ACTION_POLICY_NOTHING to the available power button
 actions, it is now possible for MATE users to disable the system's
 power button, while being in a MATE desktop session.

 This is helpful if a system's power button is designed in a way that it
 can easily be accidentally hit by the user without noticing.