### PR TITLE
Remember display backlight level set by brightness keys (on AC power)

### DIFF
--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -433,6 +433,7 @@ gpm_backlight_button_pressed_cb (GpmButton *button, const gchar *type, GpmBackli
 	GError *error = NULL;
 	guint percentage;
 	gboolean hw_changed;
+	gboolean on_battery;
 	egg_debug ("Button press event type=%s", type);
 
 	if (g_strcmp0 (type, GPM_BUTTON_BRIGHT_UP) == 0) {
@@ -448,6 +449,13 @@ gpm_backlight_button_pressed_cb (GpmButton *button, const gchar *type, GpmBackli
 			gpm_backlight_dialog_show (backlight);
 			/* save the new percentage */
 			backlight->priv->master_percentage = percentage;
+			/* if using AC power supply, save the new brightness settings */
+			g_object_get (backlight->priv->client, "on-battery", &on_battery, NULL);
+			if (!on_battery) {
+				egg_debug ("saving brightness for ac supply: %i", percentage);
+				g_settings_set_double (backlight->priv->settings, GPM_SETTINGS_BRIGHTNESS_AC,
+						       percentage*1.0);
+			}
 		}
 		/* we emit a signal for the brightness applet */
 		if (ret && hw_changed) {
@@ -467,6 +475,13 @@ gpm_backlight_button_pressed_cb (GpmButton *button, const gchar *type, GpmBackli
 			gpm_backlight_dialog_show (backlight);
 			/* save the new percentage */
 			backlight->priv->master_percentage = percentage;
+			/* if using AC power supply, save the new brightness settings */
+			g_object_get (backlight->priv->client, "on-battery", &on_battery, NULL);
+			if (!on_battery) {
+				egg_debug ("saving brightness for ac supply: %i", percentage);
+				g_settings_set_double (backlight->priv->settings, GPM_SETTINGS_BRIGHTNESS_AC,
+						       percentage*1.0);
+			}
 		}
 		/* we emit a signal for the brightness applet */
 		if (ret && hw_changed) {


### PR DESCRIPTION
This pull request makes the backlight keys handler store the stepped display backlight level into dconf key `/org/mate/power-manager/brightness-ac` while the machine is running on AC power. So when the user rebooted the machine (or re-login), brightness set via backlight keys on the last session would be restored.

This partially fixes bug #76 (in AC power case).

Full explanation of the change was elaborated in https://github.com/mate-desktop/mate-power-manager/issues/76#issuecomment-114879683

The change was originally tested on MATE Power Manager 1.8.0 (Debian GNU/Linux 7.0 "Wheezy" i386).
@Thermionix [confirmed](https://github.com/mate-desktop/mate-power-manager/issues/76#issuecomment-139411655) that this change also works on MATE Power Manager 1.10.2 (Arch Linux x86-64).

For battery power case (which is not included in this fix), there's more to be discussed about [a notion of dimmed brightness](https://github.com/mate-desktop/mate-power-manager/issues/76#issuecomment-139896235), before a separate fix could be carried out.

Note: content of this pull request is identical to pull #165, except that this pull request is done with a proper branching.