### PR TITLE
Make idle event handler always calculate backlight from configured settings

### DIFF
--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -567,7 +567,7 @@ idle_changed_cb (GpmIdle *idle, GpmIdleMode mode, GpmBacklight *backlight)
 	if (mode == GPM_IDLE_MODE_NORMAL) {
 		/* sync lcd brightness */
 		gpm_backlight_notify_system_idle_changed (backlight, FALSE);
-		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, FALSE);
+		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, TRUE);
 
 		/* ensure backlight is on */
 		ret = gpm_dpms_set_mode (backlight->priv->dpms, GPM_DPMS_MODE_ON, &error);
@@ -580,7 +580,7 @@ idle_changed_cb (GpmIdle *idle, GpmIdleMode mode, GpmBacklight *backlight)
 
 		/* sync lcd brightness */
 		gpm_backlight_notify_system_idle_changed (backlight, TRUE);
-		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, FALSE);
+		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, TRUE);
 
 		/* ensure backlight is on */
 		ret = gpm_dpms_set_mode (backlight->priv->dpms, GPM_DPMS_MODE_ON, &error);
@@ -593,7 +593,7 @@ idle_changed_cb (GpmIdle *idle, GpmIdleMode mode, GpmBacklight *backlight)
 
 		/* sync lcd brightness */
 		gpm_backlight_notify_system_idle_changed (backlight, TRUE);
-		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, FALSE);
+		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, TRUE);
 
 		/* get the DPMS state we're supposed to use on the power state */
 		g_object_get (backlight->priv->client,


### PR DESCRIPTION
This pull request makes mate-power-manager's idle event handler always calculate new backlight brightness from the configured value in GSettings, including consideration of battery power mode, preventing the daemon from accidentally using the AC backlight level when user goes on/off idle state while running on battery.

This fixes bug #150.
For the original explanation of the change, see https://github.com/mate-desktop/mate-power-manager/issues/150#issuecomment-153259857

Please note that this change is based and tested on MATE Power Manager 1.8.0, additional review may be required.