### PR TITLE
Acknowledge changes in AC backlight GSettings when running on battery

### DIFF
--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -380,7 +380,7 @@ gpm_settings_key_changed_cb (GSettings *settings, const gchar *key, GpmBacklight
 		      "on-battery", &on_battery,
 		      NULL);
 
-	if (!on_battery && g_strcmp0 (key, GPM_SETTINGS_BRIGHTNESS_AC) == 0) {
+	if (g_strcmp0 (key, GPM_SETTINGS_BRIGHTNESS_AC) == 0) {
 		backlight->priv->master_percentage = g_settings_get_double (settings, key);
 		gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, TRUE);
 


### PR DESCRIPTION
Originally `mate-power-manager` ignores changes in AC backlight level in GSettings while running on battery power, causing inconsistencies in backlight level (DC backlight depended on it, and DC-to-AC power switching depended on the up-to-date AC backlight level). The pull request makes the daemon process/acknowledge them regardless of power mode.

This fixes bug #166, bug #149, and possibly bug #147.
For full explanation of the change, see https://github.com/mate-desktop/mate-power-manager/issues/166#issuecomment-153547263

Please note that this change is based and tested on MATE Power Manager 1.8.0, additional review may be required.
