### PR TITLE
bightness: Don't remove slider background

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -709,7 +709,6 @@ gpm_applet_create_popup (GpmBrightnessApplet *applet)
 	GtkWidget *toplevel = gtk_widget_get_toplevel (frame);
 	GtkStyleContext *context;
 	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
-	gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
 	gtk_style_context_add_class(context,"mate-panel-applet-slider");
 	/*Make transparency possible in gtk3 theme3 */
  	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));


### PR DESCRIPTION
This fixes the background for GTK+ 3 themes which don't support mate-panel explicitly. Themes could still overwrite the background if they want in the usual way.