### PR TITLE
prepare gtk3 migration

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -532,7 +532,11 @@ gpm_applet_key_press_cb (GpmBrightnessApplet *applet, GdkEventKey *event)
 			gdk_keyboard_ungrab (GDK_CURRENT_TIME);
 			gdk_pointer_ungrab (GDK_CURRENT_TIME);
 			gtk_grab_remove (GTK_WIDGET(applet));
+#if GTK_CHECK_VERSION (3, 0, 0)
+			gtk_widget_set_state_flags (GTK_WIDGET(applet), GTK_STATE_FLAG_NORMAL, TRUE);
+#else
 			gtk_widget_set_state (GTK_WIDGET(applet), GTK_STATE_NORMAL);
+#endif
 			gtk_widget_hide (applet->popup);
 			applet->popped = FALSE;
 			gpm_applet_draw_cb (applet);

--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -214,6 +214,11 @@ gpm_backlight_dialog_show (GpmBacklight *backlight)
 	GdkScreen     *pointer_screen;
 	GdkRectangle   geometry;
 	int            monitor;
+#if GTK_CHECK_VERSION(3,0,0)
+        GdkDisplay    *display;
+        GdkDeviceManager *device_manager;
+        GdkDevice     *device;
+#endif
 
 	/*
 	 * get the window size
@@ -231,11 +236,21 @@ gpm_backlight_dialog_show (GpmBacklight *backlight)
 	}
 
 	pointer_screen = NULL;
+#if GTK_CHECK_VERSION(3,0,0)
+        display = gtk_widget_get_display (backlight->priv->popup);
+        device_manager = gdk_display_get_device_manager (display);
+        device = gdk_device_manager_get_client_pointer (device_manager);
+        gdk_device_get_position (device,
+				 &pointer_screen,
+				 &pointer_x,
+				 &pointer_y);
+#else
 	gdk_display_get_pointer (gtk_widget_get_display (backlight->priv->popup),
 				 &pointer_screen,
 				 &pointer_x,
 				 &pointer_y,
 				 NULL);
+#endif
 	monitor = gdk_screen_get_monitor_at_point (pointer_screen,
 						   pointer_x,
 						   pointer_y);

--- a/src/gpm-button.c
+++ b/src/gpm-button.c
@@ -171,7 +171,11 @@ gpm_button_grab_keystring (GpmButton *button, guint64 keycode)
 
 	/* we are not processing the error */
 	gdk_flush ();
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gdk_error_trap_pop_ignored ();
+#else
 	gdk_error_trap_pop ();
+#endif
 
 	egg_debug ("Grabbed modmask=%x, keycode=%li", modmask, (long int) keycode);
 	return TRUE;

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -190,6 +190,11 @@ gpm_kbd_backlight_dialog_show (GpmKbdBacklight *backlight)
 	GdkScreen     *pointer_screen;
 	GdkRectangle   geometry;
 	int            monitor;
+#if GTK_CHECK_VERSION(3,0,0)
+        GdkDisplay    *display;
+        GdkDeviceManager *device_manager;
+        GdkDevice     *device;
+#endif
 
 	/*
 	 * get the window size
@@ -207,11 +212,21 @@ gpm_kbd_backlight_dialog_show (GpmKbdBacklight *backlight)
 	}
 
 	pointer_screen = NULL;
+#if GTK_CHECK_VERSION(3,0,0)
+        display = gtk_widget_get_display (backlight->priv->popup);
+        device_manager = gdk_display_get_device_manager (display);
+        device = gdk_device_manager_get_client_pointer (device_manager);
+        gdk_device_get_position (device,
+				 &pointer_screen,
+				 &pointer_x,
+				 &pointer_y);
+#else
 	gdk_display_get_pointer (gtk_widget_get_display (backlight->priv->popup),
 				 &pointer_screen,
 				 &pointer_x,
 				 &pointer_y,
 				 NULL);
+#endif
 	monitor = gdk_screen_get_monitor_at_point (pointer_screen,
 						   pointer_x,
 						   pointer_y);

--- a/src/gsd-media-keys-window.c
+++ b/src/gsd-media-keys-window.c
@@ -30,11 +30,6 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-#define MATE_DESKTOP_USE_UNSTABLE_API
-#include <libmate-desktop/mate-desktop-utils.h>
-#endif
-
 #include "gsd-media-keys-window.h"
 
 #define MSD_MEDIA_KEYS_WINDOW_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), MSD_TYPE_MEDIA_KEYS_WINDOW, MsdMediaKeysWindowPrivate))
@@ -408,32 +403,47 @@ draw_volume_boxes (MsdMediaKeysWindow *window,
 {
         gdouble   x1;
 #if GTK_CHECK_VERSION (3, 0, 0)
-        GdkRGBA   color;
-        GtkStyleContext *style;
+        GtkStyleContext *context;
 #else
         GdkColor  color;
         double    r, g, b;
         GtkStyle *style;
 #endif
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
         _x0 += 0.5;
         _y0 += 0.5;
+#endif
         height = round (height) - 1;
         width = round (width) - 1;
         x1 = round ((width - 1) * percentage);
-
 #if GTK_CHECK_VERSION (3, 0, 0)
-        style = gtk_widget_get_style_context (GTK_WIDGET (window));
+        context = gtk_widget_get_style_context (GTK_WIDGET (window));
 #else
         style = gtk_widget_get_style (GTK_WIDGET (window));
 #endif
 
         /* bar background */
-        msd_osd_window_draw_rounded_rectangle (cr, 1.0, _x0, _y0, height / 6, width, height);
 #if GTK_CHECK_VERSION (3, 0, 0)
-        mate_desktop_gtk_style_get_dark_color (style, GTK_STATE_FLAG_NORMAL, &color);
-        cairo_set_operator (cr, CAIRO_OPERATOR_DIFFERENCE);
-        cairo_set_source_rgba (cr, color.red, color.green, color.blue, MSD_OSD_WINDOW_FG_ALPHA / 2);
+        gtk_style_context_save (context);
+        gtk_style_context_add_class (context, GTK_STYLE_CLASS_TROUGH);
+
+        gtk_render_background (context, cr, _x0, _y0, width, height);
+        gtk_render_frame (context, cr, _x0, _y0, width, height);
+
+        gtk_style_context_restore (context);
+
+        /* bar progress */
+        if (percentage < 0.01)
+                return;
+
+        gtk_style_context_save (context);
+        gtk_style_context_add_class (context, GTK_STYLE_CLASS_PROGRESSBAR);
+
+        gtk_render_background (context, cr, _x0 + 0.5, _y0 + 0.5, x1, height -1 );
+        gtk_render_frame (context, cr, _x0 + 0.5, _y0 + 0.5, x1, height -1 );
+
+        gtk_style_context_restore (context);
 #else
         msd_osd_window_color_reverse (&style->dark[GTK_STATE_NORMAL], &color);
         r = (float)color.red / 65535.0;
@@ -441,41 +451,28 @@ draw_volume_boxes (MsdMediaKeysWindow *window,
         b = (float)color.blue / 65535.0;
         msd_osd_window_draw_rounded_rectangle (cr, 1.0, _x0, _y0, height / 6, width, height);
         cairo_set_source_rgba (cr, r, g, b, MSD_OSD_WINDOW_FG_ALPHA / 2);
-#endif
         cairo_fill_preserve (cr);
 
         /* bar border */
-#if GTK_CHECK_VERSION (3, 0, 0)
-        mate_desktop_gtk_style_get_light_color (style, GTK_STATE_FLAG_NORMAL, &color);
-        cairo_set_operator (cr, CAIRO_OPERATOR_DIFFERENCE);
-        cairo_set_source_rgba (cr, color.red, color.green, color.blue, MSD_OSD_WINDOW_FG_ALPHA / 2);
-#else
         msd_osd_window_color_reverse (&style->light[GTK_STATE_NORMAL], &color);
         r = (float)color.red / 65535.0;
         g = (float)color.green / 65535.0;
         b = (float)color.blue / 65535.0;
         cairo_set_source_rgba (cr, r, g, b, MSD_OSD_WINDOW_FG_ALPHA / 2);
-#endif
         cairo_set_line_width (cr, 1);
         cairo_stroke (cr);
 
         /* bar progress */
         if (percentage < 0.01)
                 return;
-
-        msd_osd_window_draw_rounded_rectangle (cr, 1.0, _x0 + 0.5, _y0 + 0.5, height / 6 - 0.5, x1, height - 1);
-#if GTK_CHECK_VERSION (3, 0, 0)
-        gtk_style_context_get (style, GTK_STATE_FLAG_NORMAL, GTK_STYLE_PROPERTY_COLOR, &color, NULL);
-        cairo_set_operator (cr, CAIRO_OPERATOR_DIFFERENCE);
-        cairo_set_source_rgba (cr, color.red, color.green, color.blue, MSD_OSD_WINDOW_FG_ALPHA);
-#else
         color = style->bg[GTK_STATE_NORMAL];
         r = (float)color.red / 65535.0;
         g = (float)color.green / 65535.0;
         b = (float)color.blue / 65535.0;
+        msd_osd_window_draw_rounded_rectangle (cr, 1.0, _x0 + 0.5, _y0 + 0.5, height / 6 - 0.5, x1, height - 1);
         cairo_set_source_rgba (cr, r, g, b, MSD_OSD_WINDOW_FG_ALPHA);
-#endif
         cairo_fill (cr);
+#endif
 }
 
 static void
@@ -520,6 +517,14 @@ draw_action_volume (MsdMediaKeysWindow *window,
                 speaker_height = icon_box_height * 0.75;
                 speaker_cx = icon_box_x0 + speaker_width / 2;
                 speaker_cy = icon_box_y0 + speaker_height / 2;
+
+#if 0
+                g_message ("speaker box: w=%f h=%f cx=%f cy=%f",
+                           speaker_width,
+                           speaker_height,
+                           speaker_cx,
+                           speaker_cy);
+#endif
 
                 /* draw speaker symbol */
                 draw_speaker (cr, speaker_cx, speaker_cy, speaker_width, speaker_height);
@@ -621,6 +626,19 @@ draw_action_custom (MsdMediaKeysWindow *window,
         icon_box_y0 = (window_height - icon_box_height - bright_box_height) / 2;
         bright_box_x0 = round (icon_box_x0);
         bright_box_y0 = round (icon_box_height + icon_box_y0);
+
+#if 0
+        g_message ("icon box: w=%f h=%f _x0=%f _y0=%f",
+                   icon_box_width,
+                   icon_box_height,
+                   icon_box_x0,
+                   icon_box_y0);
+        g_message ("brightness box: w=%f h=%f _x0=%f _y0=%f",
+                   bright_box_width,
+                   bright_box_height,
+                   bright_box_x0,
+                   bright_box_y0);
+#endif
 
         res = render_custom (window,
                              cr,

--- a/src/msd-osd-window.h
+++ b/src/msd-osd-window.h
@@ -84,6 +84,7 @@ gboolean              msd_osd_window_is_composited     (MsdOsdWindow      *windo
 gboolean              msd_osd_window_is_valid          (MsdOsdWindow      *window);
 void                  msd_osd_window_update_and_hide   (MsdOsdWindow      *window);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 void                  msd_osd_window_draw_rounded_rectangle (cairo_t *cr,
                                                              gdouble  aspect,
                                                              gdouble  x,
@@ -92,7 +93,6 @@ void                  msd_osd_window_draw_rounded_rectangle (cairo_t *cr,
                                                              gdouble  width,
                                                              gdouble  height);
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
 void                  msd_osd_window_color_reverse          (const GdkColor *a,
                                                              GdkColor       *b);
 #endif


### PR DESCRIPTION
- fixes some deprecations
- sync OSD code with m-s-d
- in result one dep to libmate-desktop is droped
- only 3 deps to libmate-desktop/mate-aboutdialog.h are left

@monsta @lukefromdc @dnk 
Plaese test