### PR TITLE
Dev gtk3migration+progressbar

### DIFF
--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -38,6 +38,7 @@
 #endif /* HAVE_UNISTD_H */
 
 #include <glib/gi18n.h>
+#include <gtk/gtk.h>
 #include <dbus/dbus-glib.h>
 #include <libupower-glib/upower.h>
 
@@ -53,6 +54,10 @@
 #include "gpm-marshal.h"
 #include "gpm-stock-icons.h"
 #include "egg-console-kit.h"
+
+#if !GTK_CHECK_VERSION(3,0,0)
+#define gtk_widget_get_preferred_size(x,y,z) gtk_widget_size_request(x,y)
+#endif
 
 #define GPM_BACKLIGHT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GPM_TYPE_BACKLIGHT, GpmBacklightPrivate))
 
@@ -216,7 +221,7 @@ gpm_backlight_dialog_show (GpmBacklight *backlight)
 	 * know its true size, yet, so we need to jump through hoops
 	 */
 	gtk_window_get_default_size (GTK_WINDOW (backlight->priv->popup), &orig_w, &orig_h);
-	gtk_widget_size_request (backlight->priv->popup, &win_req);
+	gtk_widget_get_preferred_size (backlight->priv->popup, NULL, &win_req);
 
 	if (win_req.width > orig_w) {
 		orig_w = win_req.width;

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -22,6 +22,7 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <libupower-glib/upower.h>
+#include <gtk/gtk.h>
 
 #include "egg-debug.h"
 #include "gpm-button.h"
@@ -30,6 +31,10 @@
 #include "gpm-idle.h"
 #include "gpm-kbd-backlight.h"
 #include "gsd-media-keys-window.h"
+
+#if !GTK_CHECK_VERSION(3,0,0)
+#define gtk_widget_get_preferred_size(x,y,z) gtk_widget_size_request(x,y)
+#endif
 
 #define GPM_KBD_BACKLIGHT_GET_PRIVATE(o) (G_TYPE_INSTANCE_GET_PRIVATE ((o), GPM_TYPE_KBD_BACKLIGHT, GpmKbdBacklightPrivate))
 
@@ -192,7 +197,7 @@ gpm_kbd_backlight_dialog_show (GpmKbdBacklight *backlight)
 	 * know its true size, yet, so we need to jump through hoops
 	 */
 	gtk_window_get_default_size (GTK_WINDOW (backlight->priv->popup), &orig_w, &orig_h);
-	gtk_widget_size_request (backlight->priv->popup, &win_req);
+	gtk_widget_get_preferred_size (backlight->priv->popup, NULL, &win_req);
 
 	if (win_req.width > orig_w) {
 		orig_w = win_req.width;

--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -336,7 +336,7 @@ gpm_tray_icon_create_menu (GpmTrayIcon *icon, guint32 timestamp)
 	
 #if GTK_CHECK_VERSION (3, 0, 0)
 	/*Set up custom panel menu theme support-gtk3 only */
-	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	GtkWidget *toplevel = gtk_widget_get_toplevel (GTK_WIDGET (menu));
 	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency in menu theme */
 	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
 	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);

--- a/src/gsd-media-keys-window.c
+++ b/src/gsd-media-keys-window.c
@@ -467,6 +467,7 @@ draw_volume_boxes (MsdMediaKeysWindow *window,
         msd_osd_window_draw_rounded_rectangle (cr, 1.0, _x0 + 0.5, _y0 + 0.5, height / 6 - 0.5, x1, height - 1);
         gdk_cairo_set_source_rgba (cr, &acolor);
         cairo_fill (cr);
+        gtk_render_background (context, cr, _x0 + 0.5, _y0 + 0.5, x1, height - 1);
 
         gtk_style_context_restore (context);
 #else

--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -500,6 +500,22 @@ msd_osd_window_real_realize (GtkWidget *widget)
 }
 
 static void
+#if GTK_CHECK_VERSION (3, 0, 0)
+msd_osd_window_style_updated (GtkWidget *widget)
+{
+        GtkStyleContext *style;
+
+        GTK_WIDGET_CLASS (msd_osd_window_parent_class)->style_updated (widget);
+
+        /* We set our border width to 12 (per the MATE standard), plus the
+         * thickness of the frame that we draw in our expose handler.  This will
+         * make our child be 12 pixels away from the frame.
+         */
+
+        style = gtk_widget_get_style_context (widget);
+        gtk_container_set_border_width (GTK_CONTAINER (widget), 12);
+}
+#else
 msd_osd_window_style_set (GtkWidget *widget,
                           GtkStyle  *previous_style)
 {
@@ -515,6 +531,7 @@ msd_osd_window_style_set (GtkWidget *widget,
         style = gtk_widget_get_style (widget);
         gtk_container_set_border_width (GTK_CONTAINER (widget), 12 + MAX (style->xthickness, style->ythickness));
 }
+#endif
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 static void
@@ -522,16 +539,16 @@ msd_osd_window_get_preferred_width (GtkWidget *widget,
                                     gint *minimum_width,
                                     gint *natural_width)
 {
-        GtkStyle *style;
+        GtkStyleContext *style;
 
         GTK_WIDGET_CLASS (msd_osd_window_parent_class)->get_preferred_width (widget, minimum_width, natural_width);
 
-        /* See the comment in msd_osd_window_style_set() for why we add the thickness here */
+        /* See the comment in msd_osd_window_style_updated() for why we add the thickness here */
 
-        style = gtk_widget_get_style (widget);
+        style = gtk_widget_get_style_context (widget);
 
-        *minimum_width += style->xthickness;
-        *natural_width += style->xthickness;
+        *minimum_width += 12;
+        *natural_width += 12;
 }
 
 static void
@@ -539,16 +556,16 @@ msd_osd_window_get_preferred_height (GtkWidget *widget,
                                      gint *minimum_height,
                                      gint *natural_height)
 {
-        GtkStyle *style;
+        GtkStyleContext *style;
 
         GTK_WIDGET_CLASS (msd_osd_window_parent_class)->get_preferred_height (widget, minimum_height, natural_height);
 
-        /* See the comment in msd_osd_window_style_set() for why we add the thickness here */
+        /* See the comment in msd_osd_window_style_updated() for why we add the thickness here */
 
-        style = gtk_widget_get_style (widget);
+        style = gtk_widget_get_style_context (widget);
 
-        *minimum_height += style->ythickness;
-        *natural_height += style->ythickness;
+        *minimum_height += 12;
+        *natural_height += 12;
 }
 #else
 static void
@@ -605,12 +622,13 @@ msd_osd_window_class_init (MsdOsdWindowClass *klass)
         widget_class->show = msd_osd_window_real_show;
         widget_class->hide = msd_osd_window_real_hide;
         widget_class->realize = msd_osd_window_real_realize;
-        widget_class->style_set = msd_osd_window_style_set;
 #if GTK_CHECK_VERSION (3, 0, 0)
+        widget_class->style_updated = msd_osd_window_style_updated;
         widget_class->get_preferred_width = msd_osd_window_get_preferred_width;
         widget_class->get_preferred_height = msd_osd_window_get_preferred_height;
         widget_class->draw = msd_osd_window_draw;
 #else
+        widget_class->style_set = msd_osd_window_style_set;
         widget_class->size_request = msd_osd_window_size_request;
         widget_class->expose_event = msd_osd_window_expose_event;
 #endif

--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -503,17 +503,19 @@ static void
 #if GTK_CHECK_VERSION (3, 0, 0)
 msd_osd_window_style_updated (GtkWidget *widget)
 {
-        GtkStyleContext *style;
+        GtkStyleContext *context;
+        GtkBorder padding;
 
         GTK_WIDGET_CLASS (msd_osd_window_parent_class)->style_updated (widget);
 
         /* We set our border width to 12 (per the MATE standard), plus the
-         * thickness of the frame that we draw in our expose handler.  This will
+         * padding of the frame that we draw in our expose handler.  This will
          * make our child be 12 pixels away from the frame.
          */
 
-        style = gtk_widget_get_style_context (widget);
-        gtk_container_set_border_width (GTK_CONTAINER (widget), 12);
+        context = gtk_widget_get_style_context (widget);
+        gtk_style_context_get_padding (context, GTK_STATE_FLAG_NORMAL, &padding);
+        gtk_container_set_border_width (GTK_CONTAINER (widget), 12 + MAX (padding.left, padding.top));
 }
 #else
 msd_osd_window_style_set (GtkWidget *widget,
@@ -536,36 +538,40 @@ msd_osd_window_style_set (GtkWidget *widget,
 #if GTK_CHECK_VERSION (3, 0, 0)
 static void
 msd_osd_window_get_preferred_width (GtkWidget *widget,
-                                    gint *minimum_width,
-                                    gint *natural_width)
+                                    gint      *minimum,
+                                    gint      *natural)
 {
-        GtkStyleContext *style;
+        GtkStyleContext *context;
+        GtkBorder padding;
 
-        GTK_WIDGET_CLASS (msd_osd_window_parent_class)->get_preferred_width (widget, minimum_width, natural_width);
+        GTK_WIDGET_CLASS (msd_osd_window_parent_class)->get_preferred_width (widget, minimum, natural);
 
-        /* See the comment in msd_osd_window_style_updated() for why we add the thickness here */
+        /* See the comment in msd_osd_window_style_updated() for why we add the padding here */
 
-        style = gtk_widget_get_style_context (widget);
+        context = gtk_widget_get_style_context (widget);
+        gtk_style_context_get_padding (context, GTK_STATE_FLAG_NORMAL, &padding);
 
-        *minimum_width += 12;
-        *natural_width += 12;
+        *minimum += padding.left;
+        *natural += padding.left;
 }
 
 static void
 msd_osd_window_get_preferred_height (GtkWidget *widget,
-                                     gint *minimum_height,
-                                     gint *natural_height)
+                                     gint      *minimum,
+                                     gint      *natural)
 {
-        GtkStyleContext *style;
+        GtkStyleContext *context;
+        GtkBorder padding;
 
-        GTK_WIDGET_CLASS (msd_osd_window_parent_class)->get_preferred_height (widget, minimum_height, natural_height);
+        GTK_WIDGET_CLASS (msd_osd_window_parent_class)->get_preferred_height (widget, minimum, natural);
 
-        /* See the comment in msd_osd_window_style_updated() for why we add the thickness here */
+        /* See the comment in msd_osd_window_style_updated() for why we add the padding here */
 
-        style = gtk_widget_get_style_context (widget);
+        context = gtk_widget_get_style_context (widget);
+        gtk_style_context_get_padding (context, GTK_STATE_FLAG_NORMAL, &padding);
 
-        *minimum_height += 12;
-        *natural_height += 12;
+        *minimum += padding.top;
+        *natural += padding.top;
 }
 #else
 static void

--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -633,7 +633,6 @@ msd_osd_window_class_init (MsdOsdWindowClass *klass)
                                                         G_TYPE_POINTER);
 
 #if GTK_CHECK_VERSION (3, 20, 0)
-        GtkWidgetClass *widget_class  = GTK_WIDGET_CLASS (class);
         gtk_widget_class_set_css_name (widget_class, "MsdOsdWindow");
 #endif
 


### PR DESCRIPTION
Sync mate-power-manager brightness OSD theming with the proposed volume control OSD theming in mate-settings-daemon's "osd-progressbar" branch. Test build with GTK 3.21 worked when moved to an Intel Atom netbook, worked. Test theme "UbuntuStudio_Legacy" uses image file for OSD progressbar and it was used and shown.