### PR TITLE
Port libunique to GtkApplication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,10 +156,10 @@ case "$with_gtk" in
 	3.0) GTK_API_VERSION=3.0
 		GTK_REQUIRED=3.0.0
 		CANBERRA_GTK=libcanberra-gtk3
-		LIBUNIQUE_VERSION=3.0
 		;;
 esac
 
+AM_CONDITIONAL([GTK3], [test $GTK_REQUIRED = 3.0.0])
 AC_SUBST(GTK_API_VERSION)
 
 dnl ---------------------------------------------------------------------------
@@ -190,6 +190,7 @@ PKG_CHECK_MODULES(X11, x11 xrender)
 
 PKG_CHECK_MODULES(LIBNOTIFY, libnotify >= $LIBNOTIFY_REQUIRED)
 
+if test "$GTK_REQUIRED" != "3.0.0"; then
 PKG_CHECK_MODULES(UNIQUE, unique-$LIBUNIQUE_VERSION)
 
 AC_SUBST([UNIQUE_CFLAGS])
@@ -199,6 +200,8 @@ AC_SUBST([UNIQUE_LIBS])
 # but it's still not removed upstream in unique 1.x, so leaving it alone
 # just in case.
 UNIQUE_CFLAGS="$UNIQUE_CFLAGS -DG_CONST_RETURN=const"
+fi
+
 
 PKG_CHECK_MODULES(UPOWER, upower-glib >= $UPOWER_REQUIRED)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,6 @@ AM_CPPFLAGS =						\
 	$(DBUS_CFLAGS)					\
 	$(MATE_CFLAGS)					\
 	$(KEYRING_CFLAGS)				\
-	$(UNIQUE_CFLAGS)				\
 	$(X11_CFLAGS)					\
 	$(LIBNOTIFY_CFLAGS)				\
 	$(CANBERRA_CFLAGS)				\
@@ -38,8 +37,13 @@ AM_CPPFLAGS =						\
 	-DEGG_LOGGING="\"GPM_LOGGING\""			\
 	-DEGG_CONSOLE="\"GPM_CONSOLE\""			\
 	-I$(top_srcdir)					\
-	$(DISABLE_DEPRECATED)				\
-	$(NULL)
+	$(DISABLE_DEPRECATED)
+
+if !GTK3
+AM_CPPFLAGS +=	$(UNIQUE_CFLAGS)
+endif
+
+AM_CPPFLAGS += $(NULL)
 
 bin_PROGRAMS =						\
 	mate-power-manager				\
@@ -62,8 +66,6 @@ libgpmshared_a_SOURCES =				\
 	egg-color.h					\
 	egg-debug.h					\
 	egg-debug.c					\
-	egg-unique.h					\
-	egg-unique.c					\
 	egg-precision.h					\
 	egg-precision.c					\
 	egg-array-float.c				\
@@ -81,8 +83,13 @@ libgpmshared_a_SOURCES =				\
 	gpm-marshal.h					\
 	gpm-marshal.c					\
 	gpm-upower.c					\
-	gpm-upower.h					\
-	$(NULL)
+	gpm-upower.h
+
+if !GTK3
+libgpmshared_a_SOURCES +=	egg-unique.h egg-unique.c
+endif
+
+libgpmshared_a_SOURCES += $(NULL)
 
 mate_power_backlight_helper_SOURCES =			\
 	gpm-backlight-helper.c				\
@@ -111,9 +118,12 @@ mate_power_statistics_LDADD =				\
 	$(X11_LIBS)					\
 	$(UPOWER_LIBS)					\
 	$(MATE_LIBS)					\
-	$(UNIQUE_LIBS)					\
 	$(DBUS_LIBS)					\
 	-lm
+
+if !GTK3
+mate_power_statistics_LDADD += $(UNIQUE_LIBS)
+endif
 
 mate_power_statistics_CFLAGS =				\
 	$(WARNINGFLAGS)					\
@@ -131,10 +141,13 @@ mate_power_preferences_LDADD =				\
 	$(X11_LIBS)					\
 	$(MATE_LIBS)					\
 	$(DBUS_LIBS)					\
-	$(UNIQUE_LIBS)					\
 	$(GPM_EXTRA_LIBS)				\
 	$(UPOWER_LIBS)					\
 	-lm
+
+if !GTK3
+mate_power_preferences_LDADD += $(UNIQUE_LIBS)
+endif
 
 mate_power_preferences_CFLAGS =			\
 	$(WARNINGFLAGS)					\

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -910,3 +910,13 @@ gpm_prefs_new (void)
 	prefs = g_object_new (GPM_TYPE_PREFS, NULL);
 	return GPM_PREFS (prefs);
 }
+
+/**
+ * gpm_window:
+ * Return value: Prefs window widget.
+ **/
+GtkWidget *
+gpm_window (GpmPrefs *prefs)
+{
+	return GTK_WIDGET (gtk_builder_get_object (prefs->priv->builder, "dialog_preferences"));
+}

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -872,7 +872,9 @@ gpm_prefs_init (GpmPrefs *prefs)
 	prefs_setup_general (prefs);
 	prefs_setup_notification (prefs);
 
+#if !GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_show (main_window);
+#endif
 }
 
 /**

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -110,10 +110,17 @@ gpm_prefs_class_init (GpmPrefsClass *klass)
  * Activates (shows) the window.
  **/
 void
+#if GTK_CHECK_VERSION (3, 0, 0)
+gpm_prefs_activate_window (GtkApplication *app, GpmPrefs *prefs)
+#else
 gpm_prefs_activate_window (GpmPrefs *prefs)
+#endif
 {
 	GtkWindow *window;
 	window = GTK_WINDOW (gtk_builder_get_object (prefs->priv->builder, "dialog_preferences"));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_application_add_window (GTK_APPLICATION (app), window);
+#endif
 	gtk_window_present (window);
 }
 

--- a/src/gpm-prefs-core.h
+++ b/src/gpm-prefs-core.h
@@ -50,7 +50,11 @@ typedef struct
 
 GType		 gpm_prefs_get_type			(void);
 GpmPrefs	*gpm_prefs_new				(void);
+#if GTK_CHECK_VERSION (3, 0, 0)
+void		 gpm_prefs_activate_window		(GtkApplication *app, GpmPrefs	*prefs);
+#else
 void		 gpm_prefs_activate_window		(GpmPrefs	*prefs);
+#endif
 
 G_END_DECLS
 

--- a/src/gpm-prefs-core.h
+++ b/src/gpm-prefs-core.h
@@ -51,6 +51,7 @@ typedef struct
 GType		 gpm_prefs_get_type			(void);
 GpmPrefs	*gpm_prefs_new				(void);
 #if GTK_CHECK_VERSION (3, 0, 0)
+GtkWidget	*gpm_window				(GpmPrefs	*prefs);
 void		 gpm_prefs_activate_window		(GtkApplication *app, GpmPrefs	*prefs);
 #else
 void		 gpm_prefs_activate_window		(GpmPrefs	*prefs);

--- a/src/gpm-prefs.c
+++ b/src/gpm-prefs.c
@@ -109,6 +109,7 @@ main (int argc, char **argv)
 	gboolean ret;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	GtkApplication *app;
+	gint status;
 #else
 	EggUnique *egg_unique;
 #endif
@@ -161,7 +162,7 @@ main (int argc, char **argv)
 			  G_CALLBACK (gpm_prefs_close_cb), prefs);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	g_application_run (G_APPLICATION (app), argc, argv);
+	status = g_application_run (G_APPLICATION (app), argc, argv);
 #else
 	gtk_main ();
 #endif
@@ -177,5 +178,9 @@ unique_out:
 /* seems to not work...
 	g_option_context_free (context); */
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	return status;
+#else
 	return 0;
+#endif
 }

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1668,12 +1668,12 @@ main (int argc, char *argv[])
 	gtk_window_set_default_icon_name (GPM_ICON_APP_ICON);
 
 	/* Get the main window quit */
-	g_signal_connect_swapped (window, "delete_event", G_CALLBACK (gtk_main_quit), NULL);
-
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "button_close"));
 #if GTK_CHECK_VERSION (3, 0, 0)
+	g_signal_connect_swapped (window, "delete_event", G_CALLBACK (gtk_widget_destroy), window);
 	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gtk_widget_destroy), window);
 #else
+	g_signal_connect_swapped (window, "delete_event", G_CALLBACK (gtk_main_quit), NULL);
 	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gtk_main_quit), NULL);
 #endif
 	gtk_widget_grab_default (widget);

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1596,6 +1596,7 @@ main (int argc, char *argv[])
 	GtkTreeSelection *selection;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	GtkApplication *app;
+	gint status;
 #else
 	EggUnique *egg_unique;
 #endif
@@ -1901,7 +1902,7 @@ main (int argc, char *argv[])
 	gtk_widget_show (widget);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-	g_application_run (G_APPLICATION (app), argc, argv);
+	status = g_application_run (G_APPLICATION (app), argc, argv);
 #else
 	gtk_main ();
 #endif
@@ -1923,5 +1924,9 @@ unique_out:
 	g_object_unref (egg_unique);
 #endif
 	g_free (last_device);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	return status;
+#else
 	return 0;
+#endif
 }

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1899,11 +1899,11 @@ main (int argc, char *argv[])
 	gpm_stats_type_combo_changed_cb (widget, NULL);
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
-	gtk_widget_show (widget);
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 	status = g_application_run (G_APPLICATION (app), argc, argv);
 #else
+	gtk_widget_show (widget);
 	gtk_main ();
 #endif
 #if !UP_CHECK_VERSION(0, 99, 0)

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -33,7 +33,9 @@
 #include "egg-debug.h"
 #include "egg-color.h"
 #include "egg-array-float.h"
+#if !GTK_CHECK_VERSION (3, 0, 0)
 #include "egg-unique.h"
+#endif
 
 #include "gpm-common.h"
 #include "gpm-icon-names.h"
@@ -1175,7 +1177,11 @@ gpm_stats_devices_treeview_clicked_cb (GtkTreeSelection *selection, gboolean dat
  * gpm_stats_window_activated_cb
  **/
 static void
+#if GTK_CHECK_VERSION (3, 0, 0)
+gpm_stats_window_activated_cb (GtkApplication *app, gpointer data)
+#else
 gpm_stats_window_activated_cb (EggUnique *egg_unique, gpointer data)
+#endif
 {
 	GtkWidget *widget;
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
@@ -1562,7 +1568,11 @@ main (int argc, char *argv[])
 	GtkBox *box;
 	GtkWidget *widget;
 	GtkTreeSelection *selection;
+#if GTK_CHECK_VERSION (3, 0, 0)
+	GtkApplication *app;
+#else
 	EggUnique *egg_unique;
+#endif
 	gboolean ret;
 	UpClient *client;
 	GPtrArray *devices = NULL;
@@ -1603,12 +1613,21 @@ main (int argc, char *argv[])
 	egg_debug_init (verbose);
 	gtk_init (&argc, &argv);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	app = gtk_application_new ("org.mate.PowerManager.Statistics", 0);
+#else
 	/* are we already activated? */
 	egg_unique = egg_unique_new ();
 	ret = egg_unique_assign (egg_unique, "org.mate.PowerManager.Statistics");
 	if (!ret)
 		goto unique_out;
+#endif
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+	g_signal_connect (app, "activate",
+#else
 	g_signal_connect (egg_unique, "activated",
+#endif
 			  G_CALLBACK (gpm_stats_window_activated_cb), NULL);
 
 	/* add application specific icons to search path */
@@ -1863,8 +1882,12 @@ out:
 	g_object_unref (wakeups);
 	g_object_unref (builder);
 	g_object_unref (list_store_info);
+#if GTK_CHECK_VERSION (3, 0, 0)
+	g_object_unref (app);
+#else
 unique_out:
 	g_object_unref (egg_unique);
+#endif
 	g_free (last_device);
 	return 0;
 }

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1472,29 +1472,6 @@ gpm_stats_range_combo_changed (GtkWidget *widget, gpointer data)
 }
 
 /**
- * gpm_stats_close_cb:
- * @widget: The GtkWidget object
- **/
-#if GTK_CHECK_VERSION (3, 0, 0)
-static void
-gpm_stats_close_cb (GtkWidget *widget)
-{
-	GList *list, *next;
-	GtkWindow *win;
-
-	list = gtk_application_get_windows (GTK_APPLICATION (g_application_get_default ()));
-
-	while (list)
-	{
-		win = list->data;
-		next = list->next;
-		gtk_widget_destroy (GTK_WIDGET (win));
-		list = next;
-	}
-}
-#endif
-
-/**
  * gpm_stats_smooth_checkbox_history_cb:
  * @widget: The GtkWidget object
  **/
@@ -1592,7 +1569,7 @@ main (int argc, char *argv[])
 	gboolean verbose = FALSE;
 	GOptionContext *context;
 	GtkBox *box;
-	GtkWidget *widget;
+	GtkWidget *widget, *window;
 	GtkTreeSelection *selection;
 #if GTK_CHECK_VERSION (3, 0, 0)
 	GtkApplication *app;
@@ -1686,16 +1663,16 @@ main (int argc, char *argv[])
 	gtk_widget_set_size_request (graph_statistics, 400, 250);
 	gtk_widget_show (graph_statistics);
 
-	widget = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
-	gtk_window_set_default_size (GTK_WINDOW(widget), 800, 500);
+	window = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
+	gtk_window_set_default_size (GTK_WINDOW(window), 800, 500);
 	gtk_window_set_default_icon_name (GPM_ICON_APP_ICON);
 
 	/* Get the main window quit */
-	g_signal_connect_swapped (widget, "delete_event", G_CALLBACK (gtk_main_quit), NULL);
+	g_signal_connect_swapped (window, "delete_event", G_CALLBACK (gtk_main_quit), NULL);
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "button_close"));
 #if GTK_CHECK_VERSION (3, 0, 0)
-	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gpm_stats_close_cb), NULL);
+	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gtk_widget_destroy), window);
 #else
 	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gtk_main_quit), NULL);
 #endif

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1185,6 +1185,9 @@ gpm_stats_window_activated_cb (EggUnique *egg_unique, gpointer data)
 {
 	GtkWidget *widget;
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_application_add_window (GTK_APPLICATION (app), GTK_WINDOW (widget));
+#endif
 	gtk_window_present (GTK_WINDOW (widget));
 }
 
@@ -1469,6 +1472,29 @@ gpm_stats_range_combo_changed (GtkWidget *widget, gpointer data)
 }
 
 /**
+ * gpm_stats_close_cb:
+ * @widget: The GtkWidget object
+ **/
+#if GTK_CHECK_VERSION (3, 0, 0)
+static void
+gpm_stats_close_cb (GtkWidget *widget)
+{
+	GList *list, *next;
+	GtkWindow *win;
+
+	list = gtk_application_get_windows (GTK_APPLICATION (g_application_get_default ()));
+
+	while (list)
+	{
+		win = list->data;
+		next = list->next;
+		gtk_widget_destroy (GTK_WIDGET (win));
+		list = next;
+	}
+}
+#endif
+
+/**
  * gpm_stats_smooth_checkbox_history_cb:
  * @widget: The GtkWidget object
  **/
@@ -1667,7 +1693,11 @@ main (int argc, char *argv[])
 	g_signal_connect_swapped (widget, "delete_event", G_CALLBACK (gtk_main_quit), NULL);
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "button_close"));
+#if GTK_CHECK_VERSION (3, 0, 0)
+	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gpm_stats_close_cb), NULL);
+#else
 	g_signal_connect_swapped (widget, "clicked", G_CALLBACK (gtk_main_quit), NULL);
+#endif
 	gtk_widget_grab_default (widget);
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "button_help"));
@@ -1870,7 +1900,11 @@ main (int argc, char *argv[])
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
 	gtk_widget_show (widget);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	g_application_run (G_APPLICATION (app), argc, argv);
+#else
 	gtk_main ();
+#endif
 #if !UP_CHECK_VERSION(0, 99, 0)
 out:
 #endif


### PR DESCRIPTION
Hi, I've made an attempt to port mate-power-manager from libunique to GtkApplication.

Tested on Ubuntu-MATE 16.04.1 with Gtk 3.18.9 and everything appears to be working correctly with the patch.