### PR TITLE
Brightness: fix OSD rendering when not composited

### DIFF
--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -207,11 +207,11 @@ draw_when_not_composited (GtkWidget *widget, cairo_t *cr)
         int width;
         int height;
 
-        width = gtk_widget_get_allocated_width (widget);
-        height = gtk_widget_get_allocated_width (widget);
+        gtk_window_get_size (GTK_WINDOW (widget), &width, &height);
         context = gtk_widget_get_style_context (widget);
 
         gtk_style_context_set_state (context, GTK_STATE_FLAG_ACTIVE);
+        gtk_style_context_add_class(context,"msd-osd-window-solid");
         gtk_render_frame (context,
                           cr,
                           0,


### PR DESCRIPTION
Brightness: fix OSD rendering when not composited
Also add style class msd-osd-window-solid, same as mate-settings-daemon volume control.

Based on
https://github.com/mate-desktop/mate-settings-daemon/commit/5d580b9985b61a486c8d23eaa34091a14d01b9e0
and
https://github.com/mate-desktop/mate-settings-daemon/commit/9aa4c4e379e71ebe8436898a3af61c4c96c9cc8a