### PR TITLE
Replace deprecated UPower functions with ConsoleKit2 equivalents

### DIFF
--- a/src/egg-console-kit.c
+++ b/src/egg-console-kit.c
@@ -108,6 +108,54 @@ egg_console_kit_stop (EggConsoleKit *console, GError **error)
 }
 
 /**
+ * egg_console_kit_suspend:
+ **/
+gboolean
+egg_console_kit_suspend (EggConsoleKit *console, GError **error)
+{
+	gboolean ret;
+	GError *error_local = NULL;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "Suspend", &error_local,
+				 G_TYPE_BOOLEAN, TRUE,
+				 G_TYPE_INVALID, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't suspend: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+	return ret;
+}
+
+/**
+ * egg_console_kit_hibernate:
+ **/
+gboolean
+egg_console_kit_hibernate (EggConsoleKit *console, GError **error)
+{
+	gboolean ret;
+	GError *error_local = NULL;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "Hibernate", &error_local,
+				 G_TYPE_BOOLEAN, TRUE,
+				 G_TYPE_INVALID, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't hibernate: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+	return ret;
+}
+
+/**
  * egg_console_kit_can_stop:
  **/
 gboolean
@@ -158,6 +206,65 @@ egg_console_kit_can_restart (EggConsoleKit *console, gboolean *can_restart, GErr
 		 * so assume true if this failed */
 		*can_restart = TRUE;
 	}
+	return ret;
+}
+
+/**
+ * egg_console_kit_can_suspend:
+ **/
+gboolean
+egg_console_kit_can_suspend (EggConsoleKit *console, gboolean *can_suspend, GError **error)
+{
+	GError *error_local = NULL;
+	gboolean ret;
+	gchar  *retval;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "CanSuspend", &error_local,
+				 G_TYPE_INVALID,
+				 G_TYPE_STRING, &retval, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't do CanSuspend: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+
+	*can_suspend = g_strcmp0 (retval, "yes") == 0 ||
+		       g_strcmp0 (retval, "challenge") == 0;
+
+	g_free (retval);
+	return ret;
+}
+
+/**
+ * egg_console_kit_can_hibernate:
+ **/
+
+gboolean
+egg_console_kit_can_hibernate (EggConsoleKit *console, gboolean *can_hibernate, GError **error)
+{
+	GError *error_local = NULL;
+	gboolean ret;
+	gchar  *retval;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "CanHibernate", &error_local,
+				 G_TYPE_INVALID,
+				 G_TYPE_STRING, &retval, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't do CanHibernate: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+
+	*can_hibernate = g_strcmp0 (retval, "yes") == 0 ||
+	                 g_strcmp0 (retval, "challenge") == 0;
 	return ret;
 }
 

--- a/src/egg-console-kit.h
+++ b/src/egg-console-kit.h
@@ -58,10 +58,20 @@ gboolean	 egg_console_kit_stop			(EggConsoleKit	*console,
 							 GError		**error);
 gboolean	 egg_console_kit_restart		(EggConsoleKit	*console,
 							 GError		**error);
+gboolean	 egg_console_kit_suspend		(EggConsoleKit	*console,
+							 GError		**error);
+gboolean	 egg_console_kit_hibernate		(EggConsoleKit	*console,
+							 GError		**error);
 gboolean	 egg_console_kit_can_stop		(EggConsoleKit	*console,
 							 gboolean	*can_stop,
 							 GError		**error);
 gboolean	 egg_console_kit_can_restart		(EggConsoleKit	*console,
+							 gboolean	*can_restart,
+							 GError		**error);
+gboolean	 egg_console_kit_can_suspend		(EggConsoleKit	*console,
+							 gboolean	*can_restart,
+							 GError		**error);
+gboolean	 egg_console_kit_can_hibernate		(EggConsoleKit	*console,
 							 gboolean	*can_restart,
 							 GError		**error);
 

--- a/src/gpm-control.c
+++ b/src/gpm-control.c
@@ -39,7 +39,6 @@
 #include <glib/gi18n.h>
 #include <dbus/dbus-glib.h>
 #include <dbus/dbus-glib-lowlevel.h>
-#define UPOWER_ENABLE_DEPRECATED
 #include <libupower-glib/upower.h>
 
 #ifdef WITH_KEYRING
@@ -212,6 +211,7 @@ gpm_control_suspend (GpmControl *control, GError **error)
 	gboolean ret = FALSE;
 	gboolean do_lock;
 	gboolean nm_sleep;
+	EggConsoleKit *console;
 	GpmScreensaver *screensaver;
 	guint32 throttle_cookie = 0;
 #ifdef WITH_KEYRING
@@ -293,11 +293,12 @@ gpm_control_suspend (GpmControl *control, GError **error)
 		}
 		g_object_unref(proxy);
 	}
-#if !UP_CHECK_VERSION(0, 99, 0)
 	else {
-		ret = up_client_suspend_sync (control->priv->client, NULL, error);
+		console = egg_console_kit_new ();
+		ret = egg_console_kit_suspend (console, error);
+		g_object_unref (console);
 	}
-#endif
+
 	egg_debug ("emitting resume");
 	g_signal_emit (control, signals [RESUME], 0, GPM_CONTROL_ACTION_SUSPEND);
 
@@ -326,6 +327,7 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 	gboolean ret = FALSE;
 	gboolean do_lock;
 	gboolean nm_sleep;
+	EggConsoleKit *console;
 	GpmScreensaver *screensaver;
 	guint32 throttle_cookie = 0;
 #ifdef WITH_KEYRING
@@ -406,11 +408,12 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 			ret = TRUE;
 		}
 	}
-#if !UP_CHECK_VERSION(0, 99, 0)
 	else {
-		ret = up_client_hibernate_sync (control->priv->client, NULL, error);
+		console = egg_console_kit_new ();
+		ret = egg_console_kit_hibernate (console, error);
+		g_object_unref (console);
 	}
-#endif
+
 	egg_debug ("emitting resume");
 	g_signal_emit (control, signals [RESUME], 0, GPM_CONTROL_ACTION_HIBERNATE);
 

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -30,7 +30,6 @@
 #include <dbus/dbus-glib.h>
 #include <math.h>
 #include <string.h>
-#define UPOWER_ENABLE_DEPRECATED
 #include <libupower-glib/upower.h>
 
 #include "egg-debug.h"
@@ -756,13 +755,10 @@ gpm_prefs_init (GpmPrefs *prefs)
 		g_object_unref(proxy);
 	}
 	else {
-		/* are we allowed to shutdown? */
+		/* Get values from ConseleKit */
 		egg_console_kit_can_stop (prefs->priv->console, &prefs->priv->can_shutdown, NULL);
-#if !UP_CHECK_VERSION(0, 99, 0)
-		/* get values from UpClient */
-		prefs->priv->can_suspend = up_client_get_can_suspend (prefs->priv->client);
-		prefs->priv->can_hibernate = up_client_get_can_hibernate (prefs->priv->client);
-#endif
+		egg_console_kit_can_suspend (prefs->priv->console, &prefs->priv->can_suspend, NULL);
+		egg_console_kit_can_hibernate (prefs->priv->console, &prefs->priv->can_hibernate, NULL);
 	}
 
 	if (LOGIND_RUNNING()) {


### PR DESCRIPTION
Forward port of Infrit's CK2 path.
This requires ConsoleKit2 0.9.2.