### PR TITLE
Replace deprecated UPower functions with ConsoleKit2 equivalents, with corrections

### DIFF
--- a/src/egg-console-kit.c
+++ b/src/egg-console-kit.c
@@ -108,6 +108,54 @@ egg_console_kit_stop (EggConsoleKit *console, GError **error)
 }
 
 /**
+ * egg_console_kit_suspend:
+ **/
+gboolean
+egg_console_kit_suspend (EggConsoleKit *console, GError **error)
+{
+	gboolean ret;
+	GError *error_local = NULL;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "Suspend", &error_local,
+				 G_TYPE_BOOLEAN, TRUE,
+				 G_TYPE_INVALID, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't suspend: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+	return ret;
+}
+
+/**
+ * egg_console_kit_hibernate:
+ **/
+gboolean
+egg_console_kit_hibernate (EggConsoleKit *console, GError **error)
+{
+	gboolean ret;
+	GError *error_local = NULL;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "Hibernate", &error_local,
+				 G_TYPE_BOOLEAN, TRUE,
+				 G_TYPE_INVALID, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't hibernate: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+	return ret;
+}
+
+/**
  * egg_console_kit_can_stop:
  **/
 gboolean
@@ -158,6 +206,65 @@ egg_console_kit_can_restart (EggConsoleKit *console, gboolean *can_restart, GErr
 		 * so assume true if this failed */
 		*can_restart = TRUE;
 	}
+	return ret;
+}
+
+/**
+ * egg_console_kit_can_suspend:
+ **/
+gboolean
+egg_console_kit_can_suspend (EggConsoleKit *console, gboolean *can_suspend, GError **error)
+{
+	GError *error_local = NULL;
+	gboolean ret;
+	gchar  *retval;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "CanSuspend", &error_local,
+				 G_TYPE_INVALID,
+				 G_TYPE_STRING, &retval, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't do CanSuspend: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+
+	*can_suspend = g_strcmp0 (retval, "yes") == 0 ||
+		       g_strcmp0 (retval, "challenge") == 0;
+
+	g_free (retval);
+	return ret;
+}
+
+/**
+ * egg_console_kit_can_hibernate:
+ **/
+
+gboolean
+egg_console_kit_can_hibernate (EggConsoleKit *console, gboolean *can_hibernate, GError **error)
+{
+	GError *error_local = NULL;
+	gboolean ret;
+	gchar  *retval;
+
+	g_return_val_if_fail (EGG_IS_CONSOLE_KIT (console), FALSE);
+	g_return_val_if_fail (console->priv->proxy_manager != NULL, FALSE);
+
+	ret = dbus_g_proxy_call (console->priv->proxy_manager, "CanHibernate", &error_local,
+				 G_TYPE_INVALID,
+				 G_TYPE_STRING, &retval, G_TYPE_INVALID);
+	if (!ret) {
+		egg_warning ("Couldn't do CanHibernate: %s", error_local->message);
+		if (error != NULL)
+			*error = g_error_new (1, 0, "%s", error_local->message);
+		g_error_free (error_local);
+	}
+
+	*can_hibernate = g_strcmp0 (retval, "yes") == 0 ||
+	                 g_strcmp0 (retval, "challenge") == 0;
 	return ret;
 }
 

--- a/src/egg-console-kit.h
+++ b/src/egg-console-kit.h
@@ -58,10 +58,20 @@ gboolean	 egg_console_kit_stop			(EggConsoleKit	*console,
 							 GError		**error);
 gboolean	 egg_console_kit_restart		(EggConsoleKit	*console,
 							 GError		**error);
+gboolean	 egg_console_kit_suspend		(EggConsoleKit	*console,
+							 GError		**error);
+gboolean	 egg_console_kit_hibernate		(EggConsoleKit	*console,
+							 GError		**error);
 gboolean	 egg_console_kit_can_stop		(EggConsoleKit	*console,
 							 gboolean	*can_stop,
 							 GError		**error);
 gboolean	 egg_console_kit_can_restart		(EggConsoleKit	*console,
+							 gboolean	*can_restart,
+							 GError		**error);
+gboolean	 egg_console_kit_can_suspend		(EggConsoleKit	*console,
+							 gboolean	*can_restart,
+							 GError		**error);
+gboolean	 egg_console_kit_can_hibernate		(EggConsoleKit	*console,
 							 gboolean	*can_restart,
 							 GError		**error);
 

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -755,13 +755,10 @@ gpm_prefs_init (GpmPrefs *prefs)
 		g_object_unref(proxy);
 	}
 	else {
-		/* are we allowed to shutdown? */
+		/* Get values from ConsoleKit */
 		egg_console_kit_can_stop (prefs->priv->console, &prefs->priv->can_shutdown, NULL);
-#if !UP_CHECK_VERSION(0, 99, 0)
-		/* get values from UpClient */
-		prefs->priv->can_suspend = up_client_get_can_suspend (prefs->priv->client);
-		prefs->priv->can_hibernate = up_client_get_can_hibernate (prefs->priv->client);
-#endif
+		egg_console_kit_can_suspend (prefs->priv->console, &prefs->priv->can_suspend, NULL);
+		egg_console_kit_can_hibernate (prefs->priv->console, &prefs->priv->can_hibernate, NULL);
 	}
 
 	if (LOGIND_RUNNING()) {


### PR DESCRIPTION
Same as #209, with corrections. Now when we want to know if suspend/hibernate is allowed, we ask ConsoleKit2, not upower. This correction was needed because upower 0.99 doesn't even have the necessary properties to answer that question. :slightly_smiling_face: 

@willysr @ryanpcmcquen @joakim-tjernlund @NP-Hardass @obache
Please test it (and post your upower version just in case).
Note that it should **not** be tested with logout/shutdown dialog - that's in ```mate-session-manager```.
Instead, you need to run ```mate-power-preferences``` and assign Suspend or Hibernate action to power button (or to suspend button - not sure if any system has it). Then test it using that button.

![mate-power-prefs](https://cloud.githubusercontent.com/assets/5138986/23674714/45b80d50-0390-11e7-93f0-6a0d4077d22e.png)
