### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -749,12 +749,17 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# gnomepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for gnome-power-manager.
+# Copyright © 2005-2010 the gnome-power-manager authors.
+# This file is distributed under the same license as the gnome-power-manager package.
+# Michał Kastelik <mkastelik@gmail.com>, 2005.
+# Paweł Marciniak <pmarciniak@lodz.home.pl>, 2006.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2007.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2007-2009.
+# Piotr Zaryk <pzaryk@aviary.pl>, 2008.
+# Piotr Drąg <piotrdrag@gmail.com>, 2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2007-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.