### PR TITLE
don't use deprecated gtk_show_uri

### DIFF
--- a/applets/brightness/gpm-common.c
+++ b/applets/brightness/gpm-common.c
@@ -45,7 +45,11 @@ gpm_help_display (const gchar *link_id)
 	else
 		uri = g_strdup ("help:mate-power-manager");
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, GDK_CURRENT_TIME, &error);
+#else
 	gtk_show_uri (NULL, uri, GDK_CURRENT_TIME, &error);
+#endif
 
 	if (error != NULL) {
 		GtkWidget *d;

--- a/applets/inhibit/gpm-common.c
+++ b/applets/inhibit/gpm-common.c
@@ -45,7 +45,11 @@ gpm_help_display (const gchar *link_id)
 	else
 		uri = g_strdup ("help:mate-power-manager");
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, GDK_CURRENT_TIME, &error);
+#else
 	gtk_show_uri (NULL, uri, GDK_CURRENT_TIME, &error);
+#endif
 
 	if (error != NULL) {
 		GtkWidget *d;

--- a/src/gpm-common.c
+++ b/src/gpm-common.c
@@ -145,7 +145,11 @@ gpm_help_display (const gchar *link_id)
 	else
 		uri = g_strdup ("help:mate-power-manager");
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gtk_show_uri_on_window (NULL, uri, GDK_CURRENT_TIME, &error);
+#else
 	gtk_show_uri (NULL, uri, GDK_CURRENT_TIME, &error);
+#endif
 
 	if (error != NULL) {
 		GtkWidget *d;

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -528,7 +528,9 @@ out:
 static void
 gpm_manager_sleep_failure_response_cb (GtkDialog *dialog, gint response_id, GpmManager *manager)
 {
+#if !GTK_CHECK_VERSION (3, 22, 0)
 	GdkScreen *screen;
+#endif
 	GtkWidget *dialog_error;
 	GError *error = NULL;
 	gboolean ret;
@@ -537,8 +539,12 @@ gpm_manager_sleep_failure_response_cb (GtkDialog *dialog, gint response_id, GpmM
 	/* user clicked the help button */
 	if (response_id == GTK_RESPONSE_HELP) {
 		uri = g_settings_get_string (manager->priv->settings, GPM_SETTINGS_NOTIFY_SLEEP_FAILED_URI);
+#if GTK_CHECK_VERSION (3, 22, 0)
+		ret = gtk_show_uri_on_window (GTK_WINDOW (dialog), uri, gtk_get_current_event_time (), &error);
+#else
 		screen = gdk_screen_get_default();
 		ret = gtk_show_uri (screen, uri, gtk_get_current_event_time (), &error);
+#endif
 		if (!ret) {
 			dialog_error = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_OK,
 							       "Failed to show uri %s", error->message);


### PR DESCRIPTION
Please test.
Note for testing the help links from applets you need to edit this line
https://github.com/mate-desktop/mate-power-manager/blob/master/applets/brightness/brightness-applet.c#L856
because of this yelp issue https://bugzilla.gnome.org/show_bug.cgi?id=778553
Use
```
gpm_applet_help_cb (GtkAction *action, gpointer data)
{
	gpm_help_display ("applets-brightness");
}
```
and the link will open fine.
And do similar for inhibit-applet.

