### PR TITLE
inhibit: always scale icon to match panel size

### DIFF
--- a/applets/inhibit/inhibit-applet.c
+++ b/applets/inhibit/inhibit-applet.c
@@ -208,18 +208,7 @@ gpm_applet_size_allocate_cb (GtkWidget    *widget,
 			break;
 	}
 
-	/* copied from button-widget.c in the panel */
-	if (size < 22)
-		size = 16;
-	else if (size < 24)
-		size = 22;
-	else if (size < 32)
-		size = 24;
-	else if (size < 48)
-		size = 32;
-	else
-		size = 48;
-
+	/* Scale to the actual size of the applet, don't quantize to original icon size */
 	/* GtkImage already contains a check to do nothing if it's the same */
 	gtk_image_set_pixel_size (GTK_IMAGE(applet->image), size);
 }


### PR DESCRIPTION
Restore icon scaling to match panel size without bringing back high CPU use. Note that GNOME's behavior of matching icon size makes it easier to get sharp rendering of png icons. Tests with hidpi (window-scaling=2) looked good. In this case GTK itself is still handling all icon rendering.