### PR TITLE
po:fix msgid error in zh_CN/zh_CN.po

### DIFF
--- a/help/zh_CN/zh_CN.po
+++ b/help/zh_CN/zh_CN.po
@@ -563,11 +563,11 @@ msgstr "通知区域图标策略"
 
 #: C/mate-power-manager.xml:382(para)
 msgid ""
-"Some sliders or option boxes may be disabled if the MateConf policy keys are "
+"Some sliders or option boxes may be disabled if the dconf policy keys are "
 "not writable. This allows administrators to lock-down the actions that a "
 "user can select."
 msgstr ""
-"如果 MateConf 的一些策略键不可写，一些滑动条选项框会不能使用。这允许管理员锁定一"
+"如果dconf的一些策略键不可写，一些滑动条选项框会不能使用。这允许管理员锁定一"
 "些用户可以选择的项。"
 
 #: C/mate-power-manager.xml:390(title)


### PR DESCRIPTION
When open mate-power-preferences help manual with Chinese language, the note tips is still displayed with English language while other sections are displayed with Chinese.  The reason is that corresponding msgid in zh_CN.po is not  consistent with mate-power-manager.pot under help directory.