### PR TITLE
use libtool generated during build instead of external one

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -270,21 +270,21 @@ gpm-marshal.h: gpm-marshal.list
 	@GLIB_GENMARSHAL@ $< --prefix=gpm_marshal --header > $@
 
 org.mate.PowerManager.h: org.mate.PowerManager.xml
-	libtool --mode=execute dbus-binding-tool	\
+	$(LIBTOOL) --mode=execute dbus-binding-tool	\
 		--prefix=gpm_manager			\
 		--mode=glib-server			\
 		--output=org.mate.PowerManager.h	\
 		$(srcdir)/org.mate.PowerManager.xml
 
 org.mate.PowerManager.Backlight.h: org.mate.PowerManager.Backlight.xml
-	libtool --mode=execute dbus-binding-tool	\
+	$(LIBTOOL) --mode=execute dbus-binding-tool	\
 		--prefix=gpm_backlight			\
 		--mode=glib-server			\
 		--output=org.mate.PowerManager.Backlight.h	\
 		$(srcdir)/org.mate.PowerManager.Backlight.xml
 
 org.mate.PowerManager.KbdBacklight.h: org.mate.PowerManager.KbdBacklight.xml
-	libtool --mode=execute dbus-binding-tool	\
+	$(LIBTOOL) --mode=execute dbus-binding-tool	\
 		--prefix=gpm_kbd_backlight			\
 		--mode=glib-server			\
 		--output=org.mate.PowerManager.KbdBacklight.h	\


### PR DESCRIPTION
This comes from the patch attached to https://bugs.debian.org/912842. I think the patch can be upstreamed.

Currently m-p-m is our only project that uses an external libtool binary (which is in `libtool-bin` package in Debian). This PR switches it to local, generated `./libtool`.

How to test:
- launch the build
- check that `./libtool` is generated
- check that `src/org.mate.PowerManager.*.h` header files are still properly generated from `src/org.mate.PowerManager.xxx.xml` ones