### PR TITLE
Add conf option to disable warnings for low mouse power

### DIFF
--- a/data/org.mate.power-manager.gschema.xml.in
+++ b/data/org.mate.power-manager.gschema.xml.in
@@ -221,6 +221,11 @@
       <summary>Notify on a low power</summary>
       <description>If a notification message should be displayed when the battery is getting low.</description>
     </key>
+    <key name="notify-low-capacity-mouse" type="b">
+      <default>false</default>
+      <summary>Notify on low capacity of mouse battery</summary>
+      <description>If a notification message should be displayed when the battery is getting low.</description>
+    </key>
     <key name="info-history-graph-points" type="b">
       <default>true</default>
       <summary>Whether we should show the history data points</summary>

--- a/src/gpm-common.h
+++ b/src/gpm-common.h
@@ -98,6 +98,7 @@ G_BEGIN_DECLS
 #define GPM_SETTINGS_NOTIFY_SLEEP_FAILED		"notify-sleep-failed"
 #define GPM_SETTINGS_NOTIFY_SLEEP_FAILED_URI		"notify-sleep-failed-uri"
 #define GPM_SETTINGS_NOTIFY_LOW_POWER			"notify-low-power"
+#define GPM_SETTINGS_NOTIFY_LOW_CAPACITY_MOUSE		"notify-low-capacity-mouse"
 
 /* thresholds */
 #define GPM_SETTINGS_PERCENTAGE_LOW			"percentage-low"

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -1328,6 +1328,11 @@ gpm_manager_engine_charge_low_cb (GpmEngine *engine, UpDevice *device, GpmManage
 		message = g_strdup_printf (_("Approximately <b>%s</b> of remaining UPS backup power (%.0f%%)"),
 					   remaining_text, percentage);
 	} else if (kind == UP_DEVICE_KIND_MOUSE) {
+		gboolean notify = g_settings_get_boolean (manager->priv->settings,
+				GPM_SETTINGS_NOTIFY_LOW_CAPACITY_MOUSE);
+		if(!notify)
+			goto out;
+
 		/* TRANSLATORS: mouse is getting a little low */
 		title = _("Mouse battery low");
 
@@ -1462,6 +1467,11 @@ gpm_manager_engine_charge_critical_cb (GpmEngine *engine, UpDevice *device, GpmM
 					   remaining_text, percentage);
 		g_free (remaining_text);
 	} else if (kind == UP_DEVICE_KIND_MOUSE) {
+		gboolean notify = g_settings_get_boolean (manager->priv->settings,
+				GPM_SETTINGS_NOTIFY_LOW_CAPACITY_MOUSE);
+		if(!notify)
+			goto out;
+
 		/* TRANSLATORS: the mouse battery is very low */
 		title = _("Mouse battery low");
 


### PR DESCRIPTION
On certain mice, they can last several weeks after the first
warning on certain kinds of batteries which makes the constant
notifications quite annoying.