### PR TITLE
Help: Remove About section

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -755,28 +755,4 @@
 
 </section>
 
-<section id="about">
-  <title>About</title>
-  <para>
-    &app; was written by Mate Development.
-    To find more information about &app;, please visit the
-    <ulink url="https://github.com/mate-desktop/mate-power-manager" type="http">
-    &application; web page</ulink>.
-    Origin power-manager was written by Richard Hughes <email>richard@hughsie.com</email>.
-  </para>
-  <para>
-    To report a bug or make a suggestion regarding this application or
-    this manual, follow the directions at the
-    <ulink url="https://github.com/mate-desktop/mate-power-manager" type="http">
-    &application; Bug Page</ulink>.
-  </para>
-  <para>This program is distributed under the terms of the GNU
-    General Public license as published by the Free Software
-    Foundation; either version 2 of the License, or (at your option)
-    any later version. A copy of this license can be found at this
-    <ulink type="help" url="help:gpl">link</ulink>, or in the file
-    COPYING included with the source code of this program.
-  </para>
-</section>
-
 </article>

--- a/help/C/legal.xml
+++ b/help/C/legal.xml
@@ -72,5 +72,22 @@
 		</listitem>
 	  </orderedlist>
 	</para>
-  </legalnotice>
 
+    <formalpara>
+      <title>Software Licence</title>
+      <para>MATE Power Manager is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+      </para>
+      <para>MATE Power Manager is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+      </para>
+      <para>You should have received a copy of the GNU General Public License
+            along with MATE Power Manager; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+      </para>
+    </formalpara>
+  </legalnotice>


### PR DESCRIPTION
The info is already present in footer.