### PR TITLE
[1.20 branch] travis: use Debian Buster which has 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 
 env:
 #  - DISTRO="archlinux/base"
-  - DISTRO="debian:sid"
+  - DISTRO="debian:buster"
   - DISTRO="fedora:28"
   - DISTRO="ubuntu:18.10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ requires:
     - libdbus-glib-1-dev
     - libgcrypt20-dev
     - libglib2.0-dev
-    - libgnome-keyring-dev
     - libgtk-3-dev
     - libmate-panel-applet-dev
     - libnotify-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - ./docker-build --name ${DISTRO} --config .travis.yml --install
 
 script:
-  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools
+  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build scripts
 
 env:
 #  - DISTRO="archlinux/base"
@@ -118,11 +118,16 @@ requires:
 variables:
   - CFLAGS="-Wall -Werror=format-security"
 
-before_scripts:
+build_scripts:
+  - if [ ${DISTRO_NAME} == "debian" ];then
+  -     ./autogen.sh --without-keyring
+  - else
+  -     ./autogen.sh
+  - fi
+
+after_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh
   -     bash ./debian.sh
   - fi
-
-after_scripts:
   - make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ DISTCHECK_CONFIGURE_FLAGS =   \
 	--disable-schemas-install \
 	--disable-applets         \
 	--disable-tests \
+	--without-keyring \
 	CFLAGS='-Wno-deprecated-declarations'
 
 # Build ChangeLog from GIT  history


### PR DESCRIPTION
debian buster doesn't have the package `libgnome-keyring-dev` (is deprecated)

not sure how to fix this in travis, in debian it was fixed with:

https://salsa.debian.org/debian-mate-team/mate-power-manager/commit/8158d27caff9917c04d5e9f3c05f76cbf98430ae

https://salsa.debian.org/debian-mate-team/mate-power-manager/commit/d968620c262a378a45d65ad65cb6979670fc1238

debian bug related:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867937