### PR TITLE
Change url project's website

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+### mate-power-manager 1.23.0
+
 ### mate-power-manager 1.22.0
 
   * Translations update

--- a/README
+++ b/README
@@ -28,4 +28,4 @@ To work properly, mate-power-manager requires udevd and upowerd to be running.
 
 MATE Power Manager is a fork of GNOME Power Manager.
 
-For more information, please see http://www.mate-desktop.org/
+For more information, please see https://mate-desktop.org/

--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -834,7 +834,7 @@ gpm_applet_dialog_about_cb (GtkAction *action, gpointer data)
 	gtk_about_dialog_set_translator_credits (about, translator_credits);
 	gtk_about_dialog_set_logo (about, logo);
 	gtk_about_dialog_set_license (about, license_trans);
-	gtk_about_dialog_set_website (about, "http://www.mate-desktop.org/");
+	gtk_about_dialog_set_website (about, "https://mate-desktop.org/");
 
 	gtk_window_set_icon_name (GTK_WINDOW (about), GPM_BRIGHTNESS_APPLET_ICON);
 

--- a/applets/inhibit/inhibit-applet.c
+++ b/applets/inhibit/inhibit-applet.c
@@ -327,7 +327,7 @@ gpm_applet_dialog_about_cb (GtkAction *action, gpointer data)
 	gtk_about_dialog_set_translator_credits (about, translator_credits);
 	gtk_about_dialog_set_logo (about, logo);
 	gtk_about_dialog_set_license (about, license_trans);
-	gtk_about_dialog_set_website (about, "http://www.mate-desktop.org/");
+	gtk_about_dialog_set_website (about, "https://mate-desktop.org/");
 
 	gtk_window_set_icon_name (GTK_WINDOW (about), GPM_INHIBIT_APPLET_ICON_INHIBIT);
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.63)
 
-AC_INIT([mate-power-manager], [1.23.0], [http://www.mate-desktop.org/])
+AC_INIT([mate-power-manager], [1.23.0], [https://mate-desktop.org/])
 AC_CONFIG_SRCDIR(src)
 AM_INIT_AUTOMAKE([1.9 no-dist-gzip dist-xz check-news tar-ustar])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.63)
 
-AC_INIT([mate-power-manager], [1.22.0], [http://www.mate-desktop.org/])
+AC_INIT([mate-power-manager], [1.23.0], [http://www.mate-desktop.org/])
 AC_CONFIG_SRCDIR(src)
 AM_INIT_AUTOMAKE([1.9 no-dist-gzip dist-xz check-news tar-ustar])
 AC_CONFIG_HEADERS([config.h])

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -9,7 +9,7 @@
 <!--
       (Do not remove this comment block.)
   Template Maintained by the MATE Documentation Project:
-	  http://www.mate-desktop.org/development/
+	  https://mate-desktop.org/development/
   Template version: 2.0 beta
   Template last modified Feb 12, 2002
 -->

--- a/policy/org.mate.power.policy.in2
+++ b/policy/org.mate.power.policy.in2
@@ -10,7 +10,7 @@
   -->
 
   <vendor>MATE Power Manager</vendor>
-  <vendor_url>http://www.mate-desktop.org</vendor_url>
+  <vendor_url>https://mate-desktop.org</vendor_url>
   <icon_name>battery</icon_name>
 
   <action id="org.mate.power.backlight-helper">

--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -195,7 +195,7 @@ gpm_tray_icon_show_about_cb (GtkMenuItem *item, gpointer data)
 				"translator-credits", _("translator-credits"),
 				"icon-name", "mate-power-manager",
 				"logo-icon-name", "mate-power-manager",
-				"website", "http://www.mate-desktop.org",
+				"website", "https://mate-desktop.org",
 				NULL);
 }
 


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.