### PR TITLE
[ci] remove libgnome-keyring-dev on ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,6 @@ requires:
     - libdbus-glib-1-dev
     - libgcrypt20-dev
     - libglib2.0-dev
-    - libgnome-keyring-dev
     - libgtk-3-dev
     - libmate-panel-applet-dev
     - libnotify-dev
@@ -176,7 +175,7 @@ variables:
     -enable-checker security.insecureAPI.strcpy"'
 
 build_scripts:
-  - if [ ${DISTRO_NAME} == "debian" ];then
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
   -     ./autogen.sh --without-keyring
   -     scan-build $CHECKERS ./configure --without-keyring
   - else


### PR DESCRIPTION
seems the package `libgnome-keyring-dev` was removed in `ubuntu 19.10`