### PR TITLE
gpm-upower: build warnings

### DIFF
--- a/src/gpm-upower.c
+++ b/src/gpm-upower.c
@@ -219,7 +219,7 @@ gpm_upower_get_device_summary (UpDevice *device)
 
 	/* we care if we are on AC */
 	if (kind == UP_DEVICE_KIND_PHONE) {
-		if (state == UP_DEVICE_STATE_CHARGING || !state == UP_DEVICE_STATE_DISCHARGING) {
+		if (state == UP_DEVICE_STATE_CHARGING || !(state == UP_DEVICE_STATE_DISCHARGING)) {
 			/* TRANSLATORS: a phone is charging */
 			return g_strdup_printf (_("%s charging (%.1f%%)"), kind_desc, percentage);
 		}


### PR DESCRIPTION
gpm-upower: fix -Wlogical-not-parentheses warning

```
gpm-upower.c:222:51: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
gpm-upower.c:222:44: note: add parentheses around left hand side expression to silence this warning
  222 |   if (state == UP_DEVICE_STATE_CHARGING || !state == UP_DEVICE_STATE_DISCHARGING) {
      |                                            ^~~~~~
```