### PR TITLE
upower deprecations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ LIBPANEL_REQUIRED=1.17.0
 XRANDR_REQUIRED=1.3.0
 XPROTO_REQUIRED=7.0.15
 CANBERRA_REQUIRED=0.10
-UPOWER_REQUIRED=0.9.5
+UPOWER_REQUIRED=0.99.8
 
 dnl ---------------------------------------------------------------------------
 dnl - Check library dependencies

--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -412,11 +412,7 @@ gpm_settings_key_changed_cb (GSettings *settings, const gchar *key, GpmBacklight
  * Does the actions when the ac power source is inserted/removed.
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_backlight_client_changed_cb (UpClient *client, GParamSpec *pspec, GpmBacklight *backlight)
-#else
-gpm_backlight_client_changed_cb (UpClient *client, GpmBacklight *backlight)
-#endif
 {
 	gpm_backlight_brightness_evaluate_and_set (backlight, FALSE, TRUE);
 }
@@ -746,13 +742,8 @@ gpm_backlight_init (GpmBacklight *backlight)
 
 	/* we use up_client for the ac-adapter-changed signal */
 	backlight->priv->client = up_client_new ();
-#if UP_CHECK_VERSION(0, 99, 0)
 	g_signal_connect (backlight->priv->client, "notify",
 			  G_CALLBACK (gpm_backlight_client_changed_cb), backlight);
-#else
-	g_signal_connect (backlight->priv->client, "changed",
-			  G_CALLBACK (gpm_backlight_client_changed_cb), backlight);
-#endif
 
 	/* gets caps */
 	backlight->priv->can_dim = gpm_brightness_has_hw (backlight->priv->brightness);

--- a/src/gpm-button.c
+++ b/src/gpm-button.c
@@ -323,11 +323,7 @@ gpm_button_reset_time (GpmButton *button)
  * gpm_button_client_changed_cb
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_button_client_changed_cb (UpClient *client, GParamSpec *pspec, GpmButton *button)
-#else
-gpm_button_client_changed_cb (UpClient *client, GpmButton *button)
-#endif
 {
 	gboolean lid_is_closed;
 
@@ -366,13 +362,8 @@ gpm_button_init (GpmButton *button)
 
 	button->priv->client = up_client_new ();
 	button->priv->lid_is_closed = up_client_get_lid_is_closed (button->priv->client);
-#if UP_CHECK_VERSION(0, 99, 0)
 	g_signal_connect (button->priv->client, "notify",
 			  G_CALLBACK (gpm_button_client_changed_cb), button);
-#else
-	g_signal_connect (button->priv->client, "changed",
-			  G_CALLBACK (gpm_button_client_changed_cb), button);
-#endif
 	/* register the brightness keys */
 	gpm_button_xevent_key (button, XF86XK_PowerOff, GPM_BUTTON_POWER);
 

--- a/src/gpm-engine.c
+++ b/src/gpm-engine.c
@@ -864,7 +864,7 @@ gpm_engine_coldplug_idle_cb (GpmEngine *engine)
 	gpm_engine_recalculate_state (engine);
 
 	/* add to database */
-	array = up_client_get_devices (engine->priv->client);
+	array = up_client_get_devices2 (engine->priv->client);
 	for (i=0;i<array->len;i++) {
 		device = g_ptr_array_index (array, i);
 		gpm_engine_device_add (engine, device);

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -493,10 +493,8 @@ gpm_kbd_backlight_control_resume_cb (GpmControl *control,
  **/
 static void
 gpm_kbd_backlight_client_changed_cb (UpClient *client,
-#if UP_CHECK_VERSION(0, 99, 0)
-                    GParamSpec *pspec,
-#endif
-                    GpmKbdBacklight *backlight)
+                                     GParamSpec *pspec,
+                                     GpmKbdBacklight *backlight)
 {
    gpm_kbd_backlight_evaluate_power_source_and_set (backlight);
 }
@@ -760,13 +758,8 @@ noerr:
 
    /* Use upower for ac changed signal */
    backlight->priv->client = up_client_new ();
-#if UP_CHECK_VERSION(0, 99, 0)
    g_signal_connect (backlight->priv->client, "notify",
              G_CALLBACK (gpm_kbd_backlight_client_changed_cb), backlight);
-#else
-   g_signal_connect (backlight->priv->client, "changed",
-             G_CALLBACK (gpm_kbd_backlight_client_changed_cb), backlight);
-#endif
 
    backlight->priv->settings = g_settings_new (GPM_SETTINGS_SCHEMA);
 

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -946,11 +946,7 @@ gpm_manager_button_pressed_cb (GpmButton *button, const gchar *type, GpmManager 
  * gpm_manager_client_changed_cb:
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_manager_client_changed_cb (UpClient *client, GParamSpec *pspec, GpmManager *manager)
-#else
-gpm_manager_client_changed_cb (UpClient *client, GpmManager *manager)
-#endif
 {
 	gboolean event_when_closed;
 	gint timeout;
@@ -1852,15 +1848,10 @@ gpm_manager_init (GpmManager *manager)
 	g_signal_connect (manager->priv->settings, "changed",
 			  G_CALLBACK (gpm_manager_settings_changed_cb), manager);
 	manager->priv->client = up_client_new ();
-#if UP_CHECK_VERSION(0, 99, 0)
 	g_signal_connect (manager->priv->client, "notify::lid-is-closed",
 			  G_CALLBACK (gpm_manager_client_changed_cb), manager);
 	g_signal_connect (manager->priv->client, "notify::on-battery",
 			  G_CALLBACK (gpm_manager_client_changed_cb), manager);
-#else
-	g_signal_connect (manager->priv->client, "changed",
-			  G_CALLBACK (gpm_manager_client_changed_cb), manager);
-#endif
 
 	/* use libmatenotify */
 	notify_init (GPM_NAME);

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -818,7 +818,7 @@ gpm_prefs_init (GpmPrefs *prefs)
 		g_error_free (error);
 	}
 #endif
-	devices = up_client_get_devices (prefs->priv->client);
+	devices = up_client_get_devices2 (prefs->priv->client);
 	for (i=0; i<devices->len; i++) {
 		device = g_ptr_array_index (devices, i);
 		g_object_get (device,

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -673,9 +673,6 @@ gpm_prefs_init (GpmPrefs *prefs)
 	UpDevice *device;
 	UpDeviceKind kind;
 	GpmBrightness *brightness;
-#if !UP_CHECK_VERSION(0, 99, 0)
-	gboolean ret;
-#endif
 	guint i;
 
 	GDBusProxy *proxy;
@@ -810,14 +807,6 @@ gpm_prefs_init (GpmPrefs *prefs)
 	brightness = gpm_brightness_new ();
 	prefs->priv->has_lcd = gpm_brightness_has_hw (brightness);
 	g_object_unref (brightness);
-#if !UP_CHECK_VERSION(0, 99, 0)
-	/* get device list */
-	ret = up_client_enumerate_devices_sync (prefs->priv->client, NULL, &error);
-	if (!ret) {
-		egg_warning ("failed to get device list: %s", error->message);
-		g_error_free (error);
-	}
-#endif
 	devices = up_client_get_devices2 (prefs->priv->client);
 	for (i=0; i<devices->len; i++) {
 		device = g_ptr_array_index (devices, i);

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1190,11 +1190,7 @@ gpm_stats_window_activated_cb (GtkApplication *app, gpointer data)
  * gpm_stats_device_changed_cb:
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_stats_device_changed_cb (UpDevice *device, GParamSpec *pspec, gpointer user_data)
-#else
-gpm_stats_device_changed_cb (UpClient *client, UpDevice *device, gpointer user_data)
-#endif
 {
 	const gchar *object_path;
 	object_path = up_device_get_object_path (device);
@@ -1209,11 +1205,7 @@ gpm_stats_device_changed_cb (UpClient *client, UpDevice *device, gpointer user_d
  * gpm_stats_add_device:
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_stats_add_device (UpDevice *device, GPtrArray *devices)
-#else
-gpm_stats_add_device (UpDevice *device)
-#endif
 {
 	const gchar *id;
 	GtkTreeIter iter;
@@ -1222,13 +1214,11 @@ gpm_stats_add_device (UpDevice *device)
 	UpDeviceKind kind;
 	gchar *label, *vendor, *model;
 
-#if UP_CHECK_VERSION(0, 99, 0)
 	if (devices != NULL)
 		g_ptr_array_add (devices, device);
 
 	g_signal_connect (device, "notify",
 	                  G_CALLBACK (gpm_stats_device_changed_cb), NULL);
-#endif
 
 	/* get device properties */
 	g_object_get (device,
@@ -1270,38 +1260,25 @@ gpm_stats_data_changed_cb (UpClient *client, gpointer user_data)
  * gpm_stats_device_added_cb:
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_stats_device_added_cb (UpClient *client, UpDevice *device, GPtrArray *devices)
-#else
-gpm_stats_device_added_cb (UpClient *client, UpDevice *device, gpointer user_data)
-#endif
 {
 	const gchar *object_path;
 	object_path = up_device_get_object_path (device);
 	egg_debug ("added:     %s", object_path);
 
-#if UP_CHECK_VERSION(0, 99, 0)
 	gpm_stats_add_device (device, devices);
-#else
-	gpm_stats_add_device (device);
-#endif
 }
 
 /**
  * gpm_stats_device_removed_cb:
  **/
 static void
-#if UP_CHECK_VERSION(0, 99, 0)
 gpm_stats_device_removed_cb (UpClient *client, const gchar *object_path, GPtrArray *devices)
-#else
-gpm_stats_device_removed_cb (UpClient *client, UpDevice *device, gpointer user_data)
-#endif
 {
 	GtkTreeIter iter;
 	gchar *id = NULL;
 	gboolean ret;
 
-#if UP_CHECK_VERSION(0, 99, 0)
 	UpDevice *device_tmp;
 	guint i;
 
@@ -1312,9 +1289,6 @@ gpm_stats_device_removed_cb (UpClient *client, UpDevice *device, gpointer user_d
 			break;
 		}
 	}
-#else
-	const gchar *object_path = up_device_get_object_path (device);
-#endif
 	egg_debug ("removed:   %s", object_path);
 	if (g_strcmp0 (current_device, object_path) == 0) {
 		gtk_list_store_clear (list_store_info);
@@ -1790,12 +1764,6 @@ main (int argc, char *argv[])
 
 	wakeups = up_wakeups_new ();
 	g_signal_connect (wakeups, "data-changed", G_CALLBACK (gpm_stats_data_changed_cb), NULL);
-#if !UP_CHECK_VERSION(0, 99, 0)
-	/* coldplug */
-	ret = up_client_enumerate_devices_sync (client, NULL, NULL);
-	if (!ret)
-		goto out;
-#endif
 	devices = up_client_get_devices2 (client);
 
 	/* add devices in visually pleasing order */
@@ -1804,24 +1772,14 @@ main (int argc, char *argv[])
 			device = g_ptr_array_index (devices, i);
 			g_object_get (device, "kind", &kind, NULL);
 			if (kind == j)
-#if UP_CHECK_VERSION(0, 99, 0)
 				/* NULL == do not add it to ptr array */
 				gpm_stats_add_device (device, NULL);
-#else
-				gpm_stats_add_device (device);
-#endif
 		}
 	}
 
 	/* connect now the coldplug is done */
-#if UP_CHECK_VERSION(0, 99, 0)
 	g_signal_connect (client, "device-added", G_CALLBACK (gpm_stats_device_added_cb), devices);
 	g_signal_connect (client, "device-removed", G_CALLBACK (gpm_stats_device_removed_cb), devices);
-#else
-	g_signal_connect (client, "device-added", G_CALLBACK (gpm_stats_device_added_cb), NULL);
-	g_signal_connect (client, "device-removed", G_CALLBACK (gpm_stats_device_removed_cb), NULL);
-	g_signal_connect (client, "device-changed", G_CALLBACK (gpm_stats_device_changed_cb), NULL);
-#endif
 
 	/* set current device */
 	if (devices->len > 0) {
@@ -1858,9 +1816,6 @@ main (int argc, char *argv[])
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_stats"));
 
 	status = g_application_run (G_APPLICATION (app), argc, argv);
-#if !UP_CHECK_VERSION(0, 99, 0)
-out:
-#endif
 	if (devices != NULL)
 		g_ptr_array_unref (devices);
 

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1796,7 +1796,7 @@ main (int argc, char *argv[])
 	if (!ret)
 		goto out;
 #endif
-	devices = up_client_get_devices (client);
+	devices = up_client_get_devices2 (client);
 
 	/* add devices in visually pleasing order */
 	for (j=0; j<UP_DEVICE_KIND_LAST; j++) {


### PR DESCRIPTION
 Use up_client_get_devices2()

The previous code would have leaked all the UpDevice objects because no
free function was set on the returned GPtrArray.

With depending on upower-glib 0.99.8 get_devices() was deprecated and get_devices2() was introduced, we can simply switch to get_devices2() which does set a free function on
the returned GPtrArray, stopping the leak.

Inspired from:
https://gitlab.gnome.org/GNOME/gnome-control-center/commit/c1210c5
see upower upstream:
https://gitlab.freedesktop.org/upower/upower/commit/cb1071b

Please review.