### PR TITLE
Use WARN_CFLAGS which are only set with --enable-compiler-warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,12 +181,25 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - cd ${START_DIR}
+  - '[ -f mate-common-1.23.3.tar.xz ] || curl -Ls -o mate-common-1.23.3.tar.xz http://pub.mate-desktop.org/releases/1.23/mate-common-1.23.3.tar.xz'
+  - tar xf mate-common-1.23.3.tar.xz
+  - cd mate-common-1.23.3
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
+  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
+  - else
+  -     ./configure --prefix=/usr
+  - fi
+  - make
+  - make install
+
 build_scripts:
   - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
-  -     ./autogen.sh --without-keyring
+  -     ./autogen.sh --without-keyring --enable-compile-warnings=maximum
   -     scan-build $CHECKERS ./configure --without-keyring
   - else
-  -     ./autogen.sh
+  -     ./autogen.sh --enable-compile-warnings=maximum
   -     scan-build $CHECKERS ./configure
   - fi
   - if [ $CPU_COUNT -gt 1 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ env:
 requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/mate-power-manager
+    - autoconf-archive
     - clang
     - dbus-glib
     - file
@@ -85,6 +86,7 @@ requires:
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
     # Useful URL: https://salsa.debian.org/debian-mate-team/mate-power-manager
+    - autoconf-archive
     - clang
     - clang-tools
     - cppcheck
@@ -112,6 +114,7 @@ requires:
 
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/mate-power-manager.git
+    - autoconf-archive
     - cairo-devel
     - clang
     - clang-analyzer
@@ -135,6 +138,7 @@ requires:
     - upower-devel
 
   ubuntu:
+    - autoconf-archive
     - clang
     - clang-tools
     - git

--- a/applets/brightness/Makefile.am
+++ b/applets/brightness/Makefile.am
@@ -1,3 +1,5 @@
+NULL =
+
 AM_CPPFLAGS =							\
 	-I. -I$(srcdir) 					\
 	$(GLIB_CFLAGS)						\
@@ -18,7 +20,8 @@ AM_CPPFLAGS =							\
 	-DEGG_VERBOSE="\"GPM_VERBOSE\""				\
 	-DEGG_LOGGING="\"GPM_LOGGING\""				\
 	-DEGG_CONSOLE="\"GPM_CONSOLE\""				\
-	$(DISABLE_DEPRECATED)
+	$(DISABLE_DEPRECATED)					\
+	$(WARN_CFLAGS)						\
 	$(NULL)
 
 libexec_PROGRAMS=mate-brightness-applet

--- a/applets/inhibit/Makefile.am
+++ b/applets/inhibit/Makefile.am
@@ -1,3 +1,5 @@
+NULL =
+
 AM_CPPFLAGS =							\
 	-I. -I$(srcdir) 					\
 	$(GLIB_CFLAGS)						\
@@ -19,6 +21,7 @@ AM_CPPFLAGS =							\
 	-DEGG_LOGGING="\"GPM_LOGGING\""				\
 	-DEGG_CONSOLE="\"GPM_CONSOLE\""				\
 	$(DISABLE_DEPRECATED)					\
+	$(WARN_CFLAGS)						\
 	$(NULL)
 
 libexec_PROGRAMS=mate-inhibit-applet

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_PROG_INSTALL
 LT_INIT
 IT_PROG_INTLTOOL([0.50.1])
 
-MATE_COMPILE_WARNINGS
+MATE_COMPILE_WARNINGS([yes])
 YELP_HELP_INIT
 
 AC_PATH_PROG(GLIB_GENMARSHAL, glib-genmarshal)
@@ -44,45 +44,6 @@ if test "x$enable_deprecated" = "xyes"; then
 	DISABLE_DEPRECATED=""
 	CPPFLAGS="$CPPFLAGS $DISABLE_DEPRECATED"
 fi
-
-AC_ARG_ENABLE(extra-warn,
-        [AS_HELP_STRING([--enable-extra-warn],
-                [Enable extra warnings. gcc only. [default=no]])],,
-         [enable_extra_warn=no])
-
-if test "x$enable_extra_warn" = "xyes" && test "$GCC" = "yes"; then
-	WARNINGFLAGS="$WARNINGFLAGS -Wall"
-	WARNINGFLAGS="$WARNINGFLAGS -Wcast-align -Wno-uninitialized"
-	WARNINGFLAGS="$WARNINGFLAGS -Wmissing-declarations"
-#	WARNINGFLAGS="$WARNINGFLAGS -Wredundant-decls"
-#	WARNINGFLAGS="$WARNINGFLAGS -Wmissing-noreturn"
-	WARNINGFLAGS="$WARNINGFLAGS -Wpointer-arith"
-	WARNINGFLAGS="$WARNINGFLAGS -Wcast-align"
-	WARNINGFLAGS="$WARNINGFLAGS -Wwrite-strings"
-	WARNINGFLAGS="$WARNINGFLAGS -Winit-self"
-	WARNINGFLAGS="$WARNINGFLAGS -Wreturn-type"
-	WARNINGFLAGS="$WARNINGFLAGS -Wformat-nonliteral"
-	WARNINGFLAGS="$WARNINGFLAGS -Wformat-security"
-	WARNINGFLAGS="$WARNINGFLAGS -Wmissing-include-dirs"
-	WARNINGFLAGS="$WARNINGFLAGS -Wmissing-format-attribute"
-	WARNINGFLAGS="$WARNINGFLAGS -Wclobbered"
-	WARNINGFLAGS="$WARNINGFLAGS -Wempty-body"
-	WARNINGFLAGS="$WARNINGFLAGS -Wignored-qualifiers"
-#	WARNINGFLAGS="$WARNINGFLAGS -Wsign-compare"
-	WARNINGFLAGS="$WARNINGFLAGS -Wtype-limits"
-#	WARNINGFLAGS="$WARNINGFLAGS -Wuninitialized"
-#	WARNINGFLAGS="$WARNINGFLAGS -Waggregate-return"
-	WARNINGFLAGS="$WARNINGFLAGS -Wdeclaration-after-statement"
-	WARNINGFLAGS="$WARNINGFLAGS -Wshadow"
-	WARNINGFLAGS="$WARNINGFLAGS -Winline"
-#	WARNINGFLAGS="$WARNINGFLAGS -Wswitch-enum"
-	WARNINGFLAGS="$WARNINGFLAGS -Wmissing-parameter-type"
-	WARNINGFLAGS="$WARNINGFLAGS -Woverride-init"
-	WARNINGFLAGS="$WARNINGFLAGS -Wno-strict-aliasing"
-else
-	WARNINGFLAGS=""
-fi
-AC_SUBST(WARNINGFLAGS)
 
 dnl ---------------------------------------------------------------------------
 dnl - Debugging switches (uncomment this if you want to use gdb)
@@ -260,6 +221,7 @@ echo "
         datadir:                   ${datadir}
         compiler:                  ${CC}
         cflags:                    ${CFLAGS}
+        cwarnings:                 ${WARN_CFLAGS}
         gnome-keyring support:     ${with_keyring}
         Building extra applets:    ${enable_applets}
         Self test support:         ${have_tests}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,7 +91,7 @@ mate_power_backlight_helper_LDADD =			\
 	-lm
 
 mate_power_backlight_helper_CFLAGS =			\
-	$(WARNINGFLAGS)					\
+	$(WARN_CFLAGS)					\
 	$(NULL)
 
 mate-power-statistics-resources.h mate-power-statistics-resources.c: $(srcdir)/../data/org.mate.power-manager.statistics.gresource.xml Makefile $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies --sourcedir $(srcdir)/../data $(srcdir)/../data/org.mate.power-manager.statistics.gresource.xml)
@@ -120,7 +120,7 @@ mate_power_statistics_LDADD =				\
 	-lm
 
 mate_power_statistics_CFLAGS =				\
-	$(WARNINGFLAGS)					\
+	$(WARN_CFLAGS)					\
 	$(NULL)
 
 mate-power-preferences-resources.h mate-power-preferences-resources.c: $(srcdir)/../data/org.mate.power-manager.preferences.gresource.xml Makefile $(shell $(GLIB_COMPILE_RESOURCES) --generate-dependencies --sourcedir $(srcdir)/../data $(srcdir)/../data/org.mate.power-manager.preferences.gresource.xml)
@@ -147,8 +147,8 @@ mate_power_preferences_LDADD =				\
 	$(UPOWER_LIBS)					\
 	-lm
 
-mate_power_preferences_CFLAGS =			\
-	$(WARNINGFLAGS)					\
+mate_power_preferences_CFLAGS =				\
+	$(WARN_CFLAGS)					\
 	$(NULL)
 
 mate_power_manager_SOURCES =				\
@@ -166,8 +166,8 @@ mate_power_manager_SOURCES =				\
 	gpm-control.c					\
 	gpm-button.h					\
 	gpm-button.c					\
-	gpm-kbd-backlight.h 			\
-	gpm-kbd-backlight.c 			\
+	gpm-kbd-backlight.h				\
+	gpm-kbd-backlight.c				\
 	gpm-main.c					\
 	gpm-manager.h					\
 	gpm-manager.c					\
@@ -191,12 +191,12 @@ mate_power_manager_SOURCES =				\
 mate_power_manager_LDADD =				\
 	libgpmshared.a					\
 	$(GLIB_LIBS)					\
-	$(X11_LIBS)				\
+	$(X11_LIBS)					\
 	$(GSTREAMER_LIBS)				\
 	$(CAIRO_LIBS)					\
 	$(KEYRING_LIBS)					\
 	$(DBUS_LIBS)					\
-	$(X11_LIBS)						\
+	$(X11_LIBS)					\
 	$(CANBERRA_LIBS)				\
 	$(LIBNOTIFY_LIBS)				\
 	$(GPM_EXTRA_LIBS)				\
@@ -204,7 +204,7 @@ mate_power_manager_LDADD =				\
 	-lm
 
 mate_power_manager_CFLAGS =				\
-	$(WARNINGFLAGS)					\
+	$(WARN_CFLAGS)					\
 	$(NULL)
 
 if HAVE_TESTS
@@ -262,18 +262,22 @@ mate_power_self_test_LDADD =				\
 	$(GSTREAMER_LIBS)				\
 	$(UPOWER_LIBS)					\
 	$(DBUS_LIBS)					\
-	$(X11_LIBS)						\
+	$(X11_LIBS)					\
 	$(LIBNOTIFY_LIBS)				\
 	$(GPM_EXTRA_LIBS)				\
 	-lm
 
-mate_power_self_test_CFLAGS = -DEGG_TEST $(AM_CFLAGS) $(WARNINGFLAGS)
+mate_power_self_test_CFLAGS = 				\
+	-DEGG_TEST					\
+	$(AM_CFLAGS)					\
+	$(WARN_CFLAGS)					\
+	$(NULL)
 endif
 
 BUILT_SOURCES = 					\
-	org.mate.PowerManager.h			\
+	org.mate.PowerManager.h				\
 	org.mate.PowerManager.Backlight.h		\
-	org.mate.PowerManager.KbdBacklight.h \
+	org.mate.PowerManager.KbdBacklight.h		\
 	gpm-marshal.c					\
 	gpm-marshal.h					\
 	$(NULL)
@@ -301,7 +305,7 @@ org.mate.PowerManager.Backlight.h: org.mate.PowerManager.Backlight.xml
 
 org.mate.PowerManager.KbdBacklight.h: org.mate.PowerManager.KbdBacklight.xml
 	$(LIBTOOL) --mode=execute dbus-binding-tool	\
-		--prefix=gpm_kbd_backlight			\
+		--prefix=gpm_kbd_backlight		\
 		--mode=glib-server			\
 		--output=org.mate.PowerManager.KbdBacklight.h	\
 		$(srcdir)/org.mate.PowerManager.KbdBacklight.xml


### PR DESCRIPTION
MATE_COMPILE_WARNINGS is present in configure.ac but WARN_CFLAGS
variable is not used. git grep WARN_CFLAGS

It removes -enable-extra-warn=yes, since it is recommended to use
-enable-compile-warnings=maximum.

It sets -enable-compiler-warnings=yes, the default value for all
MATE packager for now.

It prints WARN_CFLAGS in summary table.