### PR TITLE
Set compiler debug flags using MATE_DEBUG_CHECK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,8 @@ AC_CONFIG_MACRO_DIR([m4])
 # enable nice build output on automake1.11
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
+MATE_DEBUG_CHECK([no])
+
 AC_PROG_CC
 AM_PROG_CC_C_O
 
@@ -45,10 +47,6 @@ if test "x$enable_deprecated" = "xyes"; then
 	CPPFLAGS="$CPPFLAGS $DISABLE_DEPRECATED"
 fi
 
-dnl ---------------------------------------------------------------------------
-dnl - Debugging switches (uncomment this if you want to use gdb)
-dnl ---------------------------------------------------------------------------
-CPPFLAGS="$CPPFLAGS -g"
 CPPFLAGS="$CPPFLAGS -fexceptions"
 
 dnl ---------------------------------------------------------------------------


### PR DESCRIPTION
-enable-debug=yes/info/profile/no

By default, compiler debug flags are disabled.

Test 1
```
$ ./autogen.sh --prefix=/usr -enable-debug
...
                    MATE Power Manager 1.23.0
                  =============================

        prefix:                    /usr
        datadir:                   ${datarootdir}
        compiler:                  gcc
        cflags:                     -g -O0
        gnome-keyring support:     yes
        Building extra applets:    yes
        Self test support:         no
        dbus-1 services dir:       ${datarootdir}/dbus-1/services

Now type `make' to compile mate-power-manager
```
Test 2
```
$ ./autogen.sh --prefix=/usr
...
                    MATE Power Manager 1.23.0
                  =============================

        prefix:                    /usr
        datadir:                   ${datarootdir}
        compiler:                  gcc
        cflags:
        gnome-keyring support:     yes
        Building extra applets:    yes
        Self test support:         no
        dbus-1 services dir:       ${datarootdir}/dbus-1/services

Now type `make' to compile mate-power-manager
```
It requires https://github.com/mate-desktop/mate-common/pull/29