### PR TITLE
ci: set maximum compile warnings on step scan-build ./configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,10 +197,10 @@ before_scripts:
 build_scripts:
   - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
   -     ./autogen.sh --without-keyring --enable-compile-warnings=maximum
-  -     scan-build $CHECKERS ./configure --without-keyring
+  -     scan-build $CHECKERS ./configure --without-keyring --enable-compile-warnings=maximum
   - else
   -     ./autogen.sh --enable-compile-warnings=maximum
-  -     scan-build $CHECKERS ./configure
+  -     scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
   - fi
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT


### PR DESCRIPTION
The autogen.sh compiler warning flags are overridden in the configure step.