### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -75,9 +75,6 @@ GType                gpm_brightness_applet_get_type  (void);
 #define	GPM_DBUS_PATH_BACKLIGHT		"/org/mate/PowerManager/Backlight"
 #define	GPM_DBUS_INTERFACE_BACKLIGHT	"org.mate.PowerManager.Backlight"
 
-static void      gpm_brightness_applet_class_init (GpmBrightnessAppletClass *klass);
-static void      gpm_brightness_applet_init       (GpmBrightnessApplet *applet);
-
 G_DEFINE_TYPE (GpmBrightnessApplet, gpm_brightness_applet, PANEL_TYPE_APPLET)
 
 static void      gpm_applet_get_icon              (GpmBrightnessApplet *applet);

--- a/applets/inhibit/inhibit-applet.c
+++ b/applets/inhibit/inhibit-applet.c
@@ -69,9 +69,6 @@ GType                gpm_inhibit_applet_get_type  (void);
 #define GS_DBUS_PATH		"/org/gnome/SessionManager"
 #define GS_DBUS_INTERFACE	"org.gnome.SessionManager"
 
-static void      gpm_inhibit_applet_class_init (GpmInhibitAppletClass *klass);
-static void      gpm_inhibit_applet_init       (GpmInhibitApplet *applet);
-
 G_DEFINE_TYPE (GpmInhibitApplet, gpm_inhibit_applet, PANEL_TYPE_APPLET)
 
 static void	gpm_applet_update_icon		(GpmInhibitApplet *applet);


### PR DESCRIPTION
Fixes the warnings:
```
brightness-applet.c:81:37: warning: redundant redeclaration of 'gpm_brightness_applet_init' [-Wredundant-decls]
brightness-applet.c:81:37: warning: redundant redeclaration of 'gpm_brightness_applet_class_init' [-Wredundant-decls]
inhibit-applet.c:75:34: warning: redundant redeclaration of 'gpm_inhibit_applet_init' [-Wredundant-decls]
inhibit-applet.c:75:34: warning: redundant redeclaration of 'gpm_inhibit_applet_class_init' [-Wredundant-decls]
```