### PR TITLE
Remove warning function declaration isn’t a prototype

### DIFF
--- a/src/gpm-backlight-helper.c
+++ b/src/gpm-backlight-helper.c
@@ -40,7 +40,7 @@
  * gcm_backlight_helper_get_best_backlight:
  **/
 static gchar *
-gcm_backlight_helper_get_best_backlight ()
+gcm_backlight_helper_get_best_backlight (void)
 {
 	gchar *filename;
 	guint i;


### PR DESCRIPTION
```
gpm-backlight-helper.c:43:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   43 | gcm_backlight_helper_get_best_backlight ()
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```