### PR TITLE
Remove warnings: unused variable

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -976,8 +976,6 @@ gpm_brightness_applet_name_vanished_cb (GDBusConnection *connection,
 static void
 gpm_brightness_applet_init (GpmBrightnessApplet *applet)
 {
-	DBusGConnection *connection;
-
 	/* initialize fields */
 	applet->size = 0;
 	applet->call_worked = TRUE;

--- a/applets/inhibit/inhibit-applet.c
+++ b/applets/inhibit/inhibit-applet.c
@@ -458,8 +458,6 @@ gpm_inhibit_applet_name_vanished_cb (GDBusConnection *connection,
 static void
 gpm_inhibit_applet_init (GpmInhibitApplet *applet)
 {
-	DBusGConnection *connection;
-
 	/* initialize fields */
 	applet->image = NULL;
 	applet->cookie = 0;

--- a/src/gpm-engine.c
+++ b/src/gpm-engine.c
@@ -796,8 +796,6 @@ phone_device_refresh_cb (GpmPhone *phone, guint idx, GpmEngine *engine)
 static void
 gpm_engine_init (GpmEngine *engine)
 {
-	GPtrArray *array = NULL;
-	guint i;
 	guint idle_id;
 	engine->priv = gpm_engine_get_instance_private (engine);
 

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -949,7 +949,6 @@ static void
 gpm_manager_client_changed_cb (UpClient *client, GParamSpec *pspec, GpmManager *manager)
 {
 	gboolean event_when_closed;
-	gint timeout;
 	gboolean on_battery;
 	gboolean lid_is_closed;
 

--- a/src/gpm-prefs.c
+++ b/src/gpm-prefs.c
@@ -67,7 +67,6 @@ main (int argc, char **argv)
 	gboolean verbose = FALSE;
 	GOptionContext *context;
 	GpmPrefs *prefs = NULL;
-	gboolean ret;
 	GtkApplication *app;
 	GtkWidget *window;
 	gint status;

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1209,7 +1209,6 @@ gpm_stats_add_device (UpDevice *device, GPtrArray *devices)
 {
 	const gchar *id;
 	GtkTreeIter iter;
-	const gchar *text;
 	const gchar *icon;
 	UpDeviceKind kind;
 	gchar *label, *vendor, *model;


### PR DESCRIPTION
```
gpm-manager.c:952:7: warning: unused variable ‘timeout’ [-Wunused-variable]
  952 |  gint timeout;
      |       ^~~~~~~

gpm-engine.c:800:8: warning: unused variable ‘i’ [-Wunused-variable]
  800 |  guint i;
      |        ^

gpm-engine.c:799:13: warning: unused variable ‘array’ [-Wunused-variable]
  799 |  GPtrArray *array = NULL;
      |             ^~~~~

gpm-prefs.c:70:11: warning: unused variable ‘ret’ [-Wunused-variable]
   70 |  gboolean ret;
      |           ^~~

gpm-statistics.c:1212:15: warning: unused variable ‘text’ [-Wunused-variable]
 1212 |  const gchar *text;
      |               ^~~~

brightness-applet.c:979:19: warning: unused variable ‘connection’ [-Wunused-variable]
  979 |  DBusGConnection *connection;
      |                   ^~~~~~~~~~

inhibit-applet.c:461:19: warning: unused variable ‘connection’ [-Wunused-variable]
  461 |  DBusGConnection *connection;
      |                   ^~~~~~~~~~
```