### PR TITLE
Remove warning: ‘GTimeVal’ is deprecated

### DIFF
--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -502,8 +502,7 @@ gpm_stats_update_info_page_history (UpDevice *device)
 	gboolean points;
 	GpmPointObj *point;
 	GPtrArray *new;
-	gint32 offset = 0;
-	GTimeVal timeval;
+	gint32 offset;
 
 	new = g_ptr_array_new_with_free_func ((GDestroyNotify) gpm_point_obj_free);
 	if (g_strcmp0 (history_type, GPM_HISTORY_CHARGE_VALUE) == 0) {
@@ -550,8 +549,7 @@ gpm_stats_update_info_page_history (UpDevice *device)
 	gtk_widget_hide (widget);
 	gtk_widget_show (graph_history);
 
-	g_get_current_time (&timeval);
-	offset = timeval.tv_sec;
+	offset = (gint32) (g_get_real_time () / G_USEC_PER_SEC);
 
 	for (i=0; i<array->len; i++) {
 		item = (UpHistoryItem *) g_ptr_array_index (array, i);
@@ -561,7 +559,7 @@ gpm_stats_update_info_page_history (UpDevice *device)
 			continue;
 
 		point = gpm_point_obj_new ();
-		point->x = (gint32) up_history_item_get_time (item) - offset;
+		point->x = ((gint32) up_history_item_get_time (item)) - offset;
 		point->y = up_history_item_get_value (item);
 		if (up_history_item_get_state (item) == UP_DEVICE_STATE_CHARGING)
 			point->color = egg_color_from_rgb (255, 0, 0);


### PR DESCRIPTION
Removed warnings:
```
gpm-statistics.c:507:2: warning: ‘GTimeVal’ is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
  507 |  GTimeVal timeval;
      |  ^~~~~~~~
---
gpm-statistics.c:554:2: warning: ‘g_get_current_time’ is deprecated: Use 'g_get_real_time' instead [-Wdeprecated-declarations]
  554 |  g_get_current_time (&timeval);
      |  ^~~~~~~~~~~~~~~~~~
```