### PR TITLE
gpm-backlight: silent "no dimming hardware" message unless debug

### DIFF
--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -284,7 +284,7 @@ gpm_backlight_brightness_evaluate_and_set (GpmBacklight *backlight, gboolean int
 	guint old_value;
 
 	if (backlight->priv->can_dim == FALSE) {
-		g_warning ("no dimming hardware");
+		g_debug ("no dimming hardware");
 		return FALSE;
 	}
 


### PR DESCRIPTION
#320 works fine, but it floods ~/.xsession-errors with:
```
(mate-power-manager:1589): PowerManager-WARNING **: 21:55:02.775: no dimming hardware
```