### PR TITLE
gpm-phone: silent "not connected" message unless debug

### DIFF
--- a/src/gpm-phone.c
+++ b/src/gpm-phone.c
@@ -68,7 +68,7 @@ gpm_phone_coldplug (GpmPhone *phone)
 	g_return_val_if_fail (GPM_IS_PHONE (phone), FALSE);
 
 	if (phone->priv->proxy == NULL) {
-		g_warning ("not connected");
+		g_debug ("Phone is not connected");
 		return FALSE;
 	}
 


### PR DESCRIPTION
Needed to avoid spamming ~/.xsession-errors since https://github.com/mate-desktop/mate-power-manager/commit/33e52564affb7fbc50ad68a08c43c9f70e7d1bb4

Note, i don't think that gpm-phone code is used in general, because gnome-phone is needed. And this piece of software is EOL since a long time.