### PR TITLE
Fix #327: remove unused entry from autostart

### DIFF
--- a/data/mate-power-manager.desktop.in.in
+++ b/data/mate-power-manager.desktop.in.in
@@ -6,8 +6,6 @@ Icon=mate-power-manager
 Exec=mate-power-manager
 Terminal=false
 Type=Application
-# Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Categories=
 OnlyShowIn=MATE;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-power-manager


### PR DESCRIPTION
Remove the unused Categories= entry from
the autostart dekstop file. This empty entry
and no semicolon causes the OnlyShowIn= entry
to be appended to Categories= entry.