### PR TITLE
Port to libsecret, #239

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -12,6 +12,7 @@ requires:
     - git
     - itstool
     - libcanberra
+    - libsecret
     - libgnome-keyring
     - libnotify
     - make
@@ -39,6 +40,7 @@ requires:
     - libgtk-3-dev
     - libmate-panel-applet-dev
     - libnotify-dev
+    - libsecret-1-dev
     - libtool-bin
     - libupower-glib-dev
     - libx11-dev
@@ -67,6 +69,7 @@ requires:
     - libcanberra-devel
     - libgnome-keyring-devel
     - libnotify-devel
+    - libsecret-devel
     - make
     - mate-common
     - mate-panel-devel
@@ -91,6 +94,7 @@ requires:
     - libgtk-3-dev
     - libmate-panel-applet-dev
     - libnotify-dev
+    - libsecret-1-dev
     - libtool-bin
     - libupower-glib-dev
     - libx11-dev

--- a/.build.yml
+++ b/.build.yml
@@ -146,11 +146,7 @@ build_scripts:
 
   - NOCONFIGURE=1 ./autogen.sh
 
-  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
-  -     scan-build $CHECKERS ./configure --without-keyring --enable-compile-warnings=maximum
-  - else
-  -     scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
-  - fi
+  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
 
   - if [ $CPU_COUNT -gt 1 ]; then
   -     if [ ${DISTRO_NAME} == "debian" ];then

--- a/README
+++ b/README
@@ -15,6 +15,7 @@ To build, MATE Power Manager requires
 
 	- Glib (2.36.0 or later)
 	- GTK+3 (3.14.0 or later)
+	- libsecret (0.11 or later)
 	- GNOME Keyring (3.0.0 or later)
 	- DBus (0.70 or later)
 	- libnotify (0.7.0 or later)

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,7 @@ GLIB_REQUIRED=2.50.0
 GIO_REQUIRED=2.50.0
 GDK_REQUIRED=3.22.0
 GTK_REQUIRED=3.22.0
+LIBSECRET_REQUIRED=0.11
 GNOME_KEYRING_REQUIRED=3.0.0
 DBUS_REQUIRED=1.0
 DBUS_GLIB_REQUIRED=0.70
@@ -135,6 +136,22 @@ fi
 AM_CONDITIONAL([HAVE_TESTS], [test $have_tests = yes])
 
 dnl ---------------------------------------------------------------------------
+dnl - Build libsecret support
+dnl ---------------------------------------------------------------------------
+AC_ARG_WITH(libsecret,
+        [AS_HELP_STRING([--with-libsecret],
+                        [Enable the use of libsecret])],
+        [],
+        [with_libsecret=no])
+
+AM_CONDITIONAL([WITH_LIBSECRET],[test "$with_libsecret" = "yes"])
+
+if test "$with_libsecret" = "yes"; then
+        PKG_CHECK_MODULES(LIBSECRET, libsecret-1 >= $LIBSECRET_REQUIRED)
+        AC_DEFINE([WITH_LIBSECRET],[1],[Define if LIBSECRET support is enabled])
+fi
+
+dnl ---------------------------------------------------------------------------
 dnl - Build gnome-keyring support
 dnl ---------------------------------------------------------------------------
 AC_ARG_WITH(keyring,
@@ -148,6 +165,10 @@ AM_CONDITIONAL([WITH_KEYRING],[test "$with_keyring" = "yes"])
 if test "$with_keyring" = "yes"; then
         PKG_CHECK_MODULES(KEYRING, gnome-keyring-1 >= $GNOME_KEYRING_REQUIRED)
         AC_DEFINE([WITH_KEYRING],[1],[Define if KEYRING support is enabled])
+fi
+
+if test "$with_libsecret" = "yes" -a "$with_keyring" = "yes"; then
+	AC_MSG_ERROR([Please select only 1, keyring or libsecret])
 fi
 
 dnl ---------------------------------------------------------------------------
@@ -222,6 +243,7 @@ echo "
         compiler:                  ${CC}
         cflags:                    ${CFLAGS}
         cwarnings:                 ${WARN_CFLAGS}
+        libsecret support:         ${with_libsecret}
         gnome-keyring support:     ${with_keyring}
         Building extra applets:    ${enable_applets}
         Self test support:         ${have_tests}

--- a/configure.ac
+++ b/configure.ac
@@ -139,10 +139,10 @@ dnl ---------------------------------------------------------------------------
 dnl - Build libsecret support
 dnl ---------------------------------------------------------------------------
 AC_ARG_WITH(libsecret,
-        [AS_HELP_STRING([--with-libsecret],
-                        [Enable the use of libsecret])],
+        [AS_HELP_STRING([--without-libsecret],
+                        [Disable the use of libsecret])],
         [],
-        [with_libsecret=no])
+        [with_libsecret=yes])
 
 AM_CONDITIONAL([WITH_LIBSECRET],[test "$with_libsecret" = "yes"])
 
@@ -155,10 +155,10 @@ dnl ---------------------------------------------------------------------------
 dnl - Build gnome-keyring support
 dnl ---------------------------------------------------------------------------
 AC_ARG_WITH(keyring,
-        [AS_HELP_STRING([--without-keyring],
-                        [Disable the use of gnome-keyring])],
+        [AS_HELP_STRING([--with-keyring],
+                        [Enable the use of gnome-keyring])],
         [],
-        [with_keyring=yes])
+        [with_keyring=no])
 
 AM_CONDITIONAL([WITH_KEYRING],[test "$with_keyring" = "yes"])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,7 @@ AM_CPPFLAGS =						\
 	$(GLIB_CFLAGS)					\
 	$(DBUS_CFLAGS)					\
 	$(CAIRO_CFLAGS)					\
+	$(LIBSECRET_CFLAGS)				\
 	$(KEYRING_CFLAGS)				\
 	$(X11_CFLAGS)					\
 	$(LIBNOTIFY_CFLAGS)				\
@@ -197,6 +198,7 @@ mate_power_manager_LDADD =				\
 	$(X11_LIBS)					\
 	$(GSTREAMER_LIBS)				\
 	$(CAIRO_LIBS)					\
+	$(LIBSECRET_LIBS)					\
 	$(KEYRING_LIBS)					\
 	$(DBUS_LIBS)					\
 	$(X11_LIBS)					\
@@ -259,6 +261,7 @@ mate_power_self_test_LDADD =				\
 	$(GLIB_LIBS)					\
 	$(X11_LIBS)					\
 	$(CAIRO_LIBS)					\
+	$(LIBSECRET_LIBS)					\
 	$(KEYRING_LIBS)					\
 	$(GSTREAMER_LIBS)				\
 	$(UPOWER_LIBS)					\

--- a/src/gpm-control.c
+++ b/src/gpm-control.c
@@ -368,6 +368,13 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 	EggConsoleKit *console;
 	GpmScreensaver *screensaver;
 	guint32 throttle_cookie = 0;
+#ifdef WITH_LIBSECRET
+	gboolean lock_libsecret;
+	GCancellable *libsecret_cancellable = NULL;
+	SecretService *secretservice_proxy = NULL;
+	gint num_secrets_locked;
+	GList *libsecret_collections = NULL;
+#endif /* WITH_LIBSECRET */
 #ifdef WITH_KEYRING
 	gboolean lock_gnome_keyring;
 	GnomeKeyringResult keyres;
@@ -391,6 +398,36 @@ gpm_control_hibernate (GpmControl *control, GError **error)
 		}
 	}
 
+#ifdef WITH_LIBSECRET
+	/* we should perhaps lock keyrings when sleeping #375681 */
+	lock_libsecret = g_settings_get_boolean (control->priv->settings,
+						 GPM_SETTINGS_LOCK_KEYRING_SUSPEND);
+	if (lock_libsecret) {
+		libsecret_cancellable = g_cancellable_new ();
+		secretservice_proxy = secret_service_get_sync (SECRET_SERVICE_LOAD_COLLECTIONS,
+							       libsecret_cancellable,
+							       error);
+		if (secretservice_proxy == NULL) {
+			g_warning ("failed to connect to secret service");
+		} else {
+			libsecret_collections = secret_service_get_collections (secretservice_proxy);
+			if ( libsecret_collections == NULL) {
+				g_warning ("failed to get secret collections");
+			} else {
+				num_secrets_locked = secret_service_lock_sync (secretservice_proxy,
+									       libsecret_collections,
+									       libsecret_cancellable,
+									       NULL,
+									       error);
+				if (num_secrets_locked <= 0)
+					g_warning ("could not lock keyring");
+				g_list_free (libsecret_collections);
+			}
+			g_object_unref (secretservice_proxy);
+		}
+		g_object_unref (libsecret_cancellable);
+	}
+#endif /* WITH_LIBSECRET */
 #ifdef WITH_KEYRING
 	/* we should perhaps lock keyrings when sleeping #375681 */
 	lock_gnome_keyring = g_settings_get_boolean (control->priv->settings, GPM_SETTINGS_LOCK_KEYRING_HIBERNATE);


### PR DESCRIPTION
Adds libsecret support.  I'll leave it up to you guys to decide at a future time about dropping libgnome-keyring support.  This should close out Issue #239.

I wasn't able to runtime test the code in-situ, but copied it to a standalone file and it locked the databased as expected.