### PR TITLE
Remove trailing spaces/tabs

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -291,7 +291,7 @@ gpm_applet_draw_cb (GpmBrightnessApplet *applet)
 		cairo_rectangle (cr, 0, 0, w, h);
 		cairo_fill (cr);
 	}
-	
+
 	/* draw color background */
 	if (bg_type == PANEL_COLOR_BACKGROUND && !applet->popped) {
 		gdk_cairo_set_source_rgba (cr, &color);
@@ -460,7 +460,7 @@ static gboolean
 gpm_applet_key_press_cb (GtkWidget *popup, GdkEventKey *event, GpmBrightnessApplet *applet)
 {
 	int i;
-	
+
 	switch (event->keyval) {
 	case GDK_KEY_KP_Enter:
 	case GDK_KEY_ISO_Enter:
@@ -528,7 +528,7 @@ gpm_applet_scroll_cb (GpmBrightnessApplet *applet, GdkEventScroll *event)
 			for (i = 0;i < 5;i++) {
 				gpm_applet_plus_cb (NULL, applet);
 			}
-			
+
 		} else {
 			for (i = 0;i < 5;i++) {
 				gpm_applet_minus_cb (NULL, applet);

--- a/src/egg-array-float.c
+++ b/src/egg-array-float.c
@@ -431,7 +431,7 @@ egg_array_float_test (gpointer data)
 	egg_array_float_set (array, 8, 31.0);
 	egg_array_float_set (array, 9, 30.0);
 	kernel = egg_array_float_remove_outliers (array, 3, 10.0);
-	if (kernel != NULL && kernel->len == 10) 
+	if (kernel != NULL && kernel->len == 10)
 		egg_test_success (test, "got correct length outlier array");
 	else
 		egg_test_failed (test, "got gaussian array length (%i)", array->len);
@@ -460,7 +460,7 @@ egg_array_float_test (gpointer data)
 	egg_array_float_set (array, 8, 20.0);
 	egg_array_float_set (array, 9, 50.0);
 	kernel = egg_array_float_remove_outliers (array, 3, 20.0);
-	if (kernel != NULL && kernel->len == 10) 
+	if (kernel != NULL && kernel->len == 10)
 		egg_test_success (test, "got correct length outlier array");
 	else
 		egg_test_failed (test, "got gaussian array length (%i)", array->len);
@@ -513,7 +513,7 @@ egg_array_float_test (gpointer data)
 	sigma = 1.1;
 	egg_test_title (test, "get inprecise gaussian array (%i), sigma %f", size, sigma);
 	kernel = egg_array_float_compute_gaussian (size, sigma);
-	if (kernel == NULL) 
+	if (kernel == NULL)
 		egg_test_success (test, NULL);
 	else {
 		egg_test_failed (test, "got gaussian array length (%i)", array->len);
@@ -525,7 +525,7 @@ egg_array_float_test (gpointer data)
 	sigma = 1.1;
 	egg_test_title (test, "get gaussian-9 array (%i), sigma %f", size, sigma);
 	kernel = egg_array_float_compute_gaussian (size, sigma);
-	if (kernel != NULL && kernel->len == size) 
+	if (kernel != NULL && kernel->len == size)
 		egg_test_success (test, "got correct length gaussian array");
 	else
 		egg_test_failed (test, "got gaussian array length (%i)", array->len);

--- a/src/gpm-manager.h
+++ b/src/gpm-manager.h
@@ -35,7 +35,7 @@ G_BEGIN_DECLS
 #define GPM_IS_MANAGER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), GPM_TYPE_MANAGER))
 #define GPM_MANAGER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), GPM_TYPE_MANAGER, GpmManagerClass))
 #define GPM_MANAGER_ERROR	 (gpm_manager_error_quark ())
-#define GPM_MANAGER_TYPE_ERROR	 (gpm_manager_error_get_type ()) 
+#define GPM_MANAGER_TYPE_ERROR	 (gpm_manager_error_get_type ())
 
 typedef struct GpmManagerPrivate GpmManagerPrivate;
 

--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -372,7 +372,7 @@ gpm_tray_icon_create_menu (GpmTrayIcon *icon)
 	g_signal_connect (G_OBJECT (item), "activate",
 			  G_CALLBACK (gpm_tray_icon_show_preferences_cb), icon);
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
-	
+
 	/*Set up custom panel menu theme support-gtk3 only */
 	GtkWidget *toplevel = gtk_widget_get_toplevel (GTK_WIDGET (menu));
 	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency in menu theme */

--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -2,7 +2,7 @@
  *
  * On-screen-display (OSD) window for mate-settings-daemon's plugins
  *
- * Copyright (C) 2006-2007 William Jon McCann <mccann@jhu.edu> 
+ * Copyright (C) 2006-2007 William Jon McCann <mccann@jhu.edu>
  * Copyright (C) 2009 Novell, Inc
  *
  * Authors:


### PR DESCRIPTION
```
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/[[:space:]]*$//' {} \;
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/\t*$//' {} \;
```