### PR TITLE
Fix translation of 'State' in 'Power Statistics' under en_GB

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1747,7 +1747,7 @@ msgstr "Rechargeable"
 
 #: src/gpm-statistics.c:446
 msgid "State"
-msgstr "County"
+msgstr "State"
 
 #: src/gpm-statistics.c:450
 msgid "Energy"


### PR DESCRIPTION
This fixes translation of 'State' in 'Power Statistics' which currently reads as 'County' when the locale is 'English (United Kingdom). Ref. Ubuntu-MATE bug #1859184.