### PR TITLE
mate-power-preferences: add option to enable keyboard dimming

### DIFF
--- a/data/gpm-prefs.ui
+++ b/data/gpm-prefs.ui
@@ -639,6 +639,62 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkFrame" id="frame_battery_keyboard">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_top">6</property>
+                            <property name="margin_bottom">6</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_battery_keyboard_reduce">
+                                <property name="label" translatable="yes">_Reduce keyboard backlight</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="halign">start</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label_battery_keboard">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Keyboard</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="position">1</property>

--- a/src/gpm-prefs-core.c
+++ b/src/gpm-prefs-core.c
@@ -480,6 +480,9 @@ prefs_setup_battery (GpmPrefs *prefs)
 	g_settings_bind (prefs->priv->settings, GPM_SETTINGS_IDLE_DIM_BATT,
 			 GET_WIDGET ("checkbutton_battery_display_dim"), "active",
 			 G_SETTINGS_BIND_DEFAULT);
+	g_settings_bind (prefs->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE,
+			 GET_WIDGET ("checkbutton_battery_keyboard_reduce"), "active",
+			 G_SETTINGS_BIND_DEFAULT);
 
 	if (prefs->priv->has_button_lid == FALSE)
 		gtk_widget_hide (GET_WIDGET ("box_battery_lid"));


### PR DESCRIPTION
Add option to enable/disable keyboard backlight reducing from GUI in battery mode
- added via #341 