### PR TITLE
ci: remove pangox-compat-devel from fedora deps

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -74,7 +74,6 @@ requires:
     - mate-common
     - mate-panel-devel
     - mesa-libGL-devel
-    - pangox-compat-devel
     - polkit-devel
     - popt-devel
     - redhat-rpm-config


### PR DESCRIPTION
`pangox.h` is not included in any file, nor can `pango_x_` be found in the current code.
https://gitlab.gnome.org/Archive/pangox-compat