### PR TITLE
gpm-backlight: unused function 'gpm_common_sum_scale'

### DIFF
--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -255,19 +255,6 @@ gpm_backlight_dialog_show (GpmBacklight *backlight)
 }
 
 /**
- * gpm_common_sum_scale:
- *
- * Finds the average between value1 and value2 set on a scale factor
- **/
-static inline gfloat
-gpm_common_sum_scale (gfloat value1, gfloat value2, gfloat factor)
-{
-	gfloat diff;
-	diff = value1 - value2;
-	return value2 + (diff * factor);
-}
-
-/**
  * gpm_backlight_brightness_evaluate_and_set:
  **/
 static gboolean


### PR DESCRIPTION
It removes the build warning below:
```
gpm-backlight.c:263:1: warning: unused function 'gpm_common_sum_scale' [-Wunused-function]
```
configure summary:
```
                    MATE Power Manager 1.26.0
                  =============================

        prefix:                    /usr
        datadir:                   ${datarootdir}
        compiler:                  clang
        cflags:                    -g -O0 -Wconversion -Wunused-macros -Wunused-parameter
        cwarnings:                 -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wno-unused-parameter -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Werror=format-security
        libsecret support:         yes
        gnome-keyring support:     no
        Building extra applets:    yes
        Self test support:         no
        dbus-1 services dir:       ${datarootdir}/dbus-1/services
```