### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/src/gpm-backlight-helper.c
+++ b/src/gpm-backlight-helper.c
@@ -171,7 +171,7 @@ main (gint argc, gchar *argv[])
 		{ "get-max-brightness", '\0', 0, G_OPTION_ARG_NONE, &get_max_brightness,
 		   /* command line argument */
 		  _("Get the number of brightness levels supported"), NULL },
-		{ NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	/* setup translations */

--- a/src/gpm-main.c
+++ b/src/gpm-main.c
@@ -172,7 +172,7 @@ main (int argc, char *argv[])
 		  N_("Exit after a small delay (for debugging)"), NULL },
 		{ "immediate-exit", '\0', 0, G_OPTION_ARG_NONE, &immediate_exit,
 		  N_("Exit after the manager has loaded (for debugging)"), NULL },
-		{ NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	setlocale (LC_ALL, "");

--- a/src/gpm-prefs.c
+++ b/src/gpm-prefs.c
@@ -71,7 +71,7 @@ main (int argc, char **argv)
 	gint status;
 
 	const GOptionEntry options[] = {
-		{ NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	context = g_option_context_new (N_("MATE Power Preferences"));

--- a/src/gpm-statistics.c
+++ b/src/gpm-statistics.c
@@ -1208,7 +1208,7 @@ main (int argc, char *argv[])
 		{ "device", '\0', 0, G_OPTION_ARG_STRING, &last_device,
 		  /* TRANSLATORS: show a device by default */
 		  N_("Select this device at startup"), NULL },
-		{ NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	setlocale (LC_ALL, "");


### PR DESCRIPTION
```
gpm-main.c:175:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
--
gpm-prefs.c:74:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
--
gpm-statistics.c:1211:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
--
gpm-backlight-helper.c:174:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL}
                      ^
```