### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/src/gsd-media-keys-window.c
+++ b/src/gsd-media-keys-window.c
@@ -175,7 +175,7 @@ msd_media_keys_window_set_volume_muted (MsdMediaKeysWindow *window,
         g_return_if_fail (MSD_IS_MEDIA_KEYS_WINDOW (window));
 
         if (window->priv->volume_muted != muted) {
-                window->priv->volume_muted = muted;
+                window->priv->volume_muted = (muted != FALSE);
                 volume_muted_changed (window);
         }
 }

--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -441,7 +441,7 @@ msd_osd_window_init (MsdOsdWindow *window)
 
         screen = gtk_widget_get_screen (GTK_WIDGET (window));
 
-        window->priv->is_composited = gdk_screen_is_composited (screen);
+        window->priv->is_composited = (gdk_screen_is_composited (screen) != FALSE);
         window->priv->scale_factor = gtk_widget_get_scale_factor (GTK_WIDGET (window));
 
         if (window->priv->is_composited) {


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
gsd-media-keys-window.c:178:46: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                window->priv->volume_muted = muted;
                                           ~ ^~~~~
--
msd-osd-window.c:444:39: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->is_composited = gdk_screen_is_composited (screen);
                                    ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```