### PR TITLE
Make the status icon more a11y friendly

### DIFF
--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -92,6 +92,7 @@ gpm_tray_icon_set_tooltip (GpmTrayIcon *icon, const gchar *tooltip)
 	g_return_val_if_fail (tooltip != NULL, FALSE);
 
 	gtk_status_icon_set_tooltip_text (icon->priv->status_icon, tooltip);
+gtk_status_icon_set_title (icon->priv->status_icon, tooltip);
 
 	return TRUE;
 }

--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -92,7 +92,7 @@ gpm_tray_icon_set_tooltip (GpmTrayIcon *icon, const gchar *tooltip)
 	g_return_val_if_fail (tooltip != NULL, FALSE);
 
 	gtk_status_icon_set_tooltip_text (icon->priv->status_icon, tooltip);
-gtk_status_icon_set_title (icon->priv->status_icon, tooltip);
+	gtk_status_icon_set_title (icon->priv->status_icon, tooltip);
 
 	return TRUE;
 }


### PR DESCRIPTION
This allows assistive technologies to see the tooltip of the status icon, which makes it much more useful.