### PR TITLE
gpm-brightness: add systemd-logind fallback

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ XRANDR_REQUIRED=1.3.0
 XPROTO_REQUIRED=7.0.15
 CANBERRA_REQUIRED=0.10
 UPOWER_REQUIRED=0.99.8
+LIBGUDEV_REQUIRED=234
 
 dnl ---------------------------------------------------------------------------
 dnl - Check library dependencies
@@ -173,6 +174,23 @@ if test "$with_libsecret" = "yes" -a "$with_keyring" = "yes"; then
 fi
 
 dnl ---------------------------------------------------------------------------
+dnl - Build udev support
+dnl ---------------------------------------------------------------------------
+AC_ARG_WITH(udev,
+        [AS_HELP_STRING([--with-udev],
+                        [Directly query devices for enhanced hardware support])],
+        [],
+        [with_udev=no])
+
+AM_CONDITIONAL([WITH_UDEV],[test "$with_udev" = "yes"])
+
+if test "$with_udev" = "yes"; then
+        PKG_CHECK_MODULES(UDEV, gudev-1.0 >= $LIBGUDEV_REQUIRED)
+        AC_DEFINE([WITH_UDEV],[1],[Define if UDEV support is enabled])
+fi
+
+
+dnl ---------------------------------------------------------------------------
 dnl - Build applets
 dnl ---------------------------------------------------------------------------
 AC_ARG_ENABLE(applets,
@@ -249,6 +267,7 @@ Configure summary:
 
     libsecret support ...........: ${with_libsecret}
     gnome-keyring support .......: ${with_keyring}
+    udev support ................: ${with_udev}
     Building extra applets ......: ${enable_applets}
     Self test support ...........: ${have_tests}
     dbus-1 services dir .........: $DBUS_SERVICES_DIR

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ AM_CPPFLAGS =						\
 	$(CAIRO_CFLAGS)					\
 	$(LIBSECRET_CFLAGS)				\
 	$(KEYRING_CFLAGS)				\
+	$(UDEV_CFLAGS)					\
 	$(X11_CFLAGS)					\
 	$(LIBNOTIFY_CFLAGS)				\
 	$(CANBERRA_CFLAGS)				\
@@ -84,6 +85,7 @@ mate_power_backlight_helper_SOURCES =			\
 mate_power_backlight_helper_LDADD =			\
 	libgpmshared.a					\
 	$(GLIB_LIBS)					\
+	$(UDEV_LIBS)					\
 	-lm
 
 mate_power_backlight_helper_CFLAGS =			\
@@ -109,6 +111,7 @@ mate_power_statistics_SOURCES =				\
 mate_power_statistics_LDADD =				\
 	libgpmshared.a					\
 	$(GLIB_LIBS)					\
+	$(UDEV_LIBS)					\
 	$(X11_LIBS)					\
 	$(UPOWER_LIBS)					\
 	$(CAIRO_LIBS)					\
@@ -136,6 +139,7 @@ mate_power_preferences_SOURCES =			\
 mate_power_preferences_LDADD =				\
 	libgpmshared.a					\
 	$(GLIB_LIBS)					\
+	$(UDEV_LIBS)					\
 	$(X11_LIBS)					\
 	$(CAIRO_LIBS)					\
 	$(DBUS_LIBS)					\
@@ -200,6 +204,7 @@ mate_power_manager_LDADD =				\
 	$(CAIRO_LIBS)					\
 	$(LIBSECRET_LIBS)					\
 	$(KEYRING_LIBS)					\
+	$(UDEV_LIBS)					\
 	$(DBUS_LIBS)					\
 	$(X11_LIBS)					\
 	$(CANBERRA_LIBS)				\

--- a/src/msd-osd-window.c
+++ b/src/msd-osd-window.c
@@ -375,10 +375,24 @@ msd_osd_window_constructor (GType                  type,
         return object;
 }
 
+/**
+ * msd_osd_window_finalize:
+ * @object: The OSD window instance
+ **/
+static void
+msd_osd_window_finalize (GObject *object)
+{
+        MsdOsdWindow *window = MSD_OSD_WINDOW (object);
+        remove_hide_timeout (window);
+        G_OBJECT_CLASS (msd_osd_window_parent_class)->finalize (object);
+}
+
 static void
 msd_osd_window_class_init (MsdOsdWindowClass *klass)
 {
         GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+        gobject_class->finalize = msd_osd_window_finalize;
+
         GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
         gobject_class->constructor = msd_osd_window_constructor;


### PR DESCRIPTION
systemd 243 [added support for an additional mechanism for managing backlight brightness](https://github.com/systemd/systemd/pull/12424) in the form of a D-Bus call to the current logind session. The feature allows any user to manipulate backlights and LEDs without superuser privileges.

This change modifies the brightness backend so that it uses the logind API as a fallback with a higher preference than the external binary helper. In other words, we will try to adjust brightness by:

1. Changing the `Backlight` or `BACKLIGHT` property on the XRandR output
2. Making a D-Bus `SetBrightness` call to the logind session
3. Calling the external helper with pkexec

This change is roughly inspired by a [similar adjustment to gnome-settings-daemon](https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/142), although in their case they prefer the D-Bus approach over XRR; this seems overly blunt to me but perhaps makes sense in the context of future Wayland support.

Unfortunately, there's no corresponding `GetBrightness` call available, nor is there any way to enumerate backlight devices through D-Bus. We add libgudev as a dependency so that we can look up current backlights and brightness values as needed. In theory, a future revision to this code could eliminate the get-brightness and get-max-brightness options to the external helper, as they are Linux-dependent anyway (they use Linux sysfs paths), preferring the same in-process udev lookups we use here.

We gate this feature entirely behind a `--with-udev` configure flag so users who don't have a sufficient libgudev version won't be stuck. As the required version has landed in Debian stable, we may be able to make it a hard requirement on Linux in the not-too-distant future.

I've also included a small bugfix to the OSD window class. It seems that when a compositor is switched out from under the daemon while it has an OSD window open, the callback to close the window after a given time will cause a segfault.