### PR TITLE
Fix -Wmissing-prototypes warnings

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -906,7 +906,7 @@ brightness_changed_cb (DBusGProxy          *proxy,
 /**
  * gpm_brightness_applet_dbus_connect:
  **/
-gboolean
+static gboolean
 gpm_brightness_applet_dbus_connect (GpmBrightnessApplet *applet)
 {
 	GError *error = NULL;
@@ -950,7 +950,7 @@ gpm_brightness_applet_dbus_connect (GpmBrightnessApplet *applet)
 /**
  * gpm_brightness_applet_dbus_disconnect:
  **/
-gboolean
+static gboolean
 gpm_brightness_applet_dbus_disconnect (GpmBrightnessApplet *applet)
 {
 	if (applet->proxy != NULL) {
@@ -978,7 +978,7 @@ gpm_brightness_applet_name_appeared_cb (GDBusConnection *connection,
 /**
  * gpm_brightness_applet_name_vanished_cb:
  **/
-void
+static void
 gpm_brightness_applet_name_vanished_cb (GDBusConnection *connection,
 					 const gchar *name,
 					 GpmBrightnessApplet *applet)

--- a/applets/inhibit/inhibit-applet.c
+++ b/applets/inhibit/inhibit-applet.c
@@ -358,7 +358,7 @@ gpm_inhibit_applet_class_init (GpmInhibitAppletClass *class)
 /**
  * gpm_inhibit_applet_dbus_connect:
  **/
-gboolean
+static gboolean
 gpm_inhibit_applet_dbus_connect (GpmInhibitApplet *applet)
 {
 	GError *error = NULL;
@@ -395,7 +395,7 @@ gpm_inhibit_applet_dbus_connect (GpmInhibitApplet *applet)
 /**
  * gpm_inhibit_applet_dbus_disconnect:
  **/
-gboolean
+static gboolean
 gpm_inhibit_applet_dbus_disconnect (GpmInhibitApplet *applet)
 {
 	if (applet->proxy != NULL) {
@@ -425,7 +425,7 @@ gpm_inhibit_applet_name_appeared_cb (GDBusConnection *connection,
 /**
  * gpm_inhibit_applet_name_vanished_cb:
  **/
-void
+static void
 gpm_inhibit_applet_name_vanished_cb (GDBusConnection *connection,
 				     const gchar *name,
 				     GpmInhibitApplet *applet)


### PR DESCRIPTION
Test:
```
 CFLAGS="-Werror=missing-prototypes" ./autogen.sh --prefix=/usr && make && sudo make install
```
Warnings
```
mate-power-manager.make.log:brightness-applet.c:910:1: warning: no previous prototype for function 'gpm_brightness_applet_dbus_connect' [-Wmissing-prototypes]
mate-power-manager.make.log:brightness-applet.c:954:1: warning: no previous prototype for function 'gpm_brightness_applet_dbus_disconnect' [-Wmissing-prototypes]
mate-power-manager.make.log:brightness-applet.c:982:1: warning: no previous prototype for function 'gpm_brightness_applet_name_vanished_cb' [-Wmissing-prototypes]
mate-power-manager.make.log:inhibit-applet.c:362:1: warning: no previous prototype for function 'gpm_inhibit_applet_dbus_connect' [-Wmissing-prototypes]
mate-power-manager.make.log:inhibit-applet.c:399:1: warning: no previous prototype for function 'gpm_inhibit_applet_dbus_disconnect' [-Wmissing-prototypes]
mate-power-manager.make.log:inhibit-applet.c:429:1: warning: no previous prototype for function 'gpm_inhibit_applet_name_vanished_cb' [-Wmissing-prototypes]
```