### PR TITLE
Fix brightness applet scroll

### DIFF
--- a/applets/brightness/brightness-applet.c
+++ b/applets/brightness/brightness-applet.c
@@ -115,6 +115,13 @@ static void      gpm_applet_destroy_cb            (GtkWidget *widget);
  * too long one will seem unresponsive. */
 #define GPM_BRIGHTNESS_APPLET_SLIDER_FREQUENCY	100
 
+/* Brightness percentage changes for each input method */
+#define GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_BUTTON 1  /* plus/minus buttons in the popup */
+#define GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_ARROW 1  /* arrow keys when the popup is open */
+#define GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_SCROLL 5  /* scrolling over the indicator icon */
+#define GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_PAGE 10  /* page up/down keys when the popup is open */
+
+
 /**
  * gpm_applet_get_brightness:
  * Return value: Success value, or zero for failure
@@ -404,6 +411,26 @@ gpm_applet_update_popup_level (GpmBrightnessApplet *applet)
 }
 
 /**
+ * gpm_applet_adjust_brightness:
+ * @applet: Brightness applet instance
+ *
+ * Change brightness by a given percentage and keep the slider value in sync.
+ **/
+static void
+gpm_applet_adjust_brightness (GpmBrightnessApplet *applet, int percent)
+{
+	if (applet->level == -1) {
+		return;
+	}
+	if (percent > 0) {
+		applet->level = applet->level <= (100 - percent) ? applet->level + percent : 100;
+	} else {
+		applet->level = applet->level >= -percent ? applet->level + percent : 0;
+	}
+	gtk_range_set_value (GTK_RANGE(applet->slider), applet->level);
+}
+
+/**
  * gpm_applet_plus_cb:
  * @widget: The sending widget (plus button)
  * @applet: Brightness applet instance
@@ -413,11 +440,7 @@ gpm_applet_update_popup_level (GpmBrightnessApplet *applet)
 static gboolean
 gpm_applet_plus_cb (GtkWidget *w, GpmBrightnessApplet *applet)
 {
-	if (applet->level < 100) {
-		applet->level++;
-	}
-	applet->call_worked = gpm_applet_set_brightness (applet);
-	gpm_applet_update_popup_level (applet);
+	gpm_applet_adjust_brightness (applet, GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_BUTTON);
 	return TRUE;
 }
 
@@ -431,11 +454,7 @@ gpm_applet_plus_cb (GtkWidget *w, GpmBrightnessApplet *applet)
 static gboolean
 gpm_applet_minus_cb (GtkWidget *w, GpmBrightnessApplet *applet)
 {
-	if (applet->level > 0) {
-		applet->level--;
-	}
-	applet->call_worked = gpm_applet_set_brightness (applet);
-	gpm_applet_update_popup_level (applet);
+	gpm_applet_adjust_brightness (applet, -GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_BUTTON);
 	return TRUE;
 }
 
@@ -487,8 +506,6 @@ gpm_applet_slide_cb (GtkWidget *w, GpmBrightnessApplet *applet)
 static gboolean
 gpm_applet_key_press_cb (GtkWidget *popup, GdkEventKey *event, GpmBrightnessApplet *applet)
 {
-	int i;
-
 	switch (event->keyval) {
 	case GDK_KEY_KP_Enter:
 	case GDK_KEY_ISO_Enter:
@@ -508,25 +525,21 @@ gpm_applet_key_press_cb (GtkWidget *popup, GdkEventKey *event, GpmBrightnessAppl
 		}
 		break;
 	case GDK_KEY_Page_Up:
-		for (i = 0;i < 10;i++) {
-			gpm_applet_plus_cb (NULL, applet);
-		}
+		gpm_applet_adjust_brightness (applet, GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_PAGE);
 		return TRUE;
 		break;
 	case GDK_KEY_Left:
 	case GDK_KEY_Up:
-		gpm_applet_plus_cb (NULL, applet);
+		gpm_applet_adjust_brightness (applet, GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_ARROW);
 		return TRUE;
 		break;
 	case GDK_KEY_Page_Down:
-		for (i = 0;i < 10;i++) {
-			gpm_applet_minus_cb (NULL, applet);
-		}
+		gpm_applet_adjust_brightness (applet, -GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_PAGE);
 		return TRUE;
 		break;
 	case GDK_KEY_Right:
 	case GDK_KEY_Down:
-		gpm_applet_minus_cb (NULL, applet);
+		gpm_applet_adjust_brightness (applet, -GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_ARROW);
 		return TRUE;
 		break;
 	default:
@@ -549,18 +562,11 @@ gpm_applet_key_press_cb (GtkWidget *popup, GdkEventKey *event, GpmBrightnessAppl
 static gboolean
 gpm_applet_scroll_cb (GpmBrightnessApplet *applet, GdkEventScroll *event)
 {
-	int i;
-
 	if (event->type == GDK_SCROLL) {
 		if (event->direction == GDK_SCROLL_UP) {
-			for (i = 0;i < 5;i++) {
-				gpm_applet_plus_cb (NULL, applet);
-			}
-
+			gpm_applet_adjust_brightness (applet, GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_SCROLL);
 		} else {
-			for (i = 0;i < 5;i++) {
-				gpm_applet_minus_cb (NULL, applet);
-			}
+			gpm_applet_adjust_brightness (applet, -GPM_BRIGHTNESS_APPLET_PERCENT_CHANGE_SCROLL);
 		}
 		return TRUE;
 	}
@@ -710,7 +716,7 @@ gpm_applet_popup_cb (GpmBrightnessApplet *applet, GdkEventButton *event)
 	/* otherwise pop */
 	applet->popped = TRUE;
 
-	/* create a new popup (initial or if panel parameters changed) */
+	/* create a new popup (if panel parameters changed) */
 	if (applet->popup == NULL) {
 		gpm_applet_create_popup (applet);
 	}
@@ -1025,6 +1031,10 @@ gpm_brightness_applet_init (GpmBrightnessApplet *applet)
 	/* prepare */
 	mate_panel_applet_set_flags (MATE_PANEL_APPLET (applet), MATE_PANEL_APPLET_EXPAND_MINOR);
 	gtk_widget_set_events (GTK_WIDGET (applet), GDK_SCROLL_MASK);
+
+	/* Create popup (slider) upfront, so that we can keep it
+	 * up to date from scroll events before it's ever opened. */
+	gpm_applet_create_popup (applet);
 
 	/* show */
 	gtk_widget_show_all (GTK_WIDGET(applet));


### PR DESCRIPTION
This PR makes it possible to use the mouse wheel scroll to adjust brightness when hovering over the applet icon (without opening the popup). 

There was code that was supposed to handle these scroll events already but it repeatedly bumped it by one percent, which only caused very high cpu usage, while most changes didn't even take effect. 

This PR reuses `gpm_applet_slide_cb` and `gpm_applet_slide_delayed_cb` to throttle all adjustments regardless of how they were triggered.

One thing I don't fully understand is why we get a 10% change when scrolling over the slider in the popup. I don't see where that's specified, maybe that's the GTK default.

Also, the scroll event isn't triggered always/everywhere as the description in `gpm_applet_scroll_cb` suggests. If the popup is open then scroll doesn't work over the applet icon, or outside the slider area in the popup. That's a problem without this PR as well. I couldn't make it work but happy to try if anyone has suggestions.

I've tested this only on Ubuntu Mate 22.04 / Thinkpad T480.