### PR TITLE
Brightness, Inhibit: mark both applets incompatable with wayland

### DIFF
--- a/applets/brightness/org.mate.BrightnessApplet.mate-panel-applet.desktop.in.in
+++ b/applets/brightness/org.mate.BrightnessApplet.mate-panel-applet.desktop.in.in
@@ -10,6 +10,7 @@ Description=Adjusts Laptop panel brightness
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-brightness-applet
 MateComponentId=OAFIID:MATE_BrightnessApplet
+Platforms=X11;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-power-manager
 X-MATE-Bugzilla-Component=applets

--- a/applets/inhibit/org.mate.InhibitApplet.mate-panel-applet.desktop.in.in
+++ b/applets/inhibit/org.mate.InhibitApplet.mate-panel-applet.desktop.in.in
@@ -10,6 +10,7 @@ Description=Allows user to inhibit automatic power saving
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-inhibit-applet
 MateComponentId=OAFIID:MATE_InhibitApplet
+Platforms=X11;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-power-manager
 X-MATE-Bugzilla-Component=applets


### PR DESCRIPTION
*Brightness applet depends on Xrandr, and wlr-randr wayland equivalent does not yet offer brightness control
*Inhibit applet depends on Xevent and on x11 extension DPMS (X Display Power Management Signaling)

