### PR TITLE
Avoid fatal errors on specific modules

### DIFF
--- a/src/gpm-brightness.c
+++ b/src/gpm-brightness.c
@@ -131,7 +131,7 @@ gpm_brightness_helper_get_value (const gchar *argument)
 	ret = g_spawn_command_line_sync (command,
 					 &stdout_data, NULL, &exit_status, &error);
 	if (!ret) {
-		g_error ("failed to get value: %s", error->message);
+		g_warning ("failed to get value: %s", error->message);
 		g_error_free (error);
 		goto out;
 	}
@@ -162,7 +162,7 @@ gpm_brightness_helper_set_value (const gchar *argument, gint value)
 	command = g_strdup_printf ("pkexec " SBINDIR "/mate-power-backlight-helper --%s %i", argument, value);
 	ret = g_spawn_command_line_sync (command, NULL, NULL, &exit_status, &error);
 	if (!ret) {
-		g_error ("failed to get value: %s", error->message);
+		g_warning ("failed to get value: %s", error->message);
 		g_error_free (error);
 		goto out;
 	}
@@ -261,7 +261,7 @@ gpm_brightness_setup_display (GpmBrightness *brightness)
 	/* get the display */
 	brightness->priv->dpy = GDK_DISPLAY_XDISPLAY (gdk_display_get_default());
 	if (!brightness->priv->dpy) {
-		g_error ("Cannot open display");
+		g_critical ("Cannot open display");
 		return FALSE;
 	}
 	/* is XRandR new enough? */

--- a/src/gpm-button.c
+++ b/src/gpm-button.c
@@ -270,9 +270,9 @@ gpm_button_is_lid_closed (GpmButton *button)
 						       NULL,
 						       &error );
 		if (proxy == NULL) {
-			g_error("Error connecting to dbus - %s", error->message);
+			g_warning ("Error connecting to dbus - %s", error->message);
 			g_error_free (error);
-			return -1;
+			goto err;
 		}
 
 		res = g_dbus_proxy_call_sync (proxy, "Get",
@@ -292,15 +292,16 @@ gpm_button_is_lid_closed (GpmButton *button)
 			g_variant_unref (res);
 			return lid;
 		} else if (error != NULL ) {
-			g_error ("Error in dbus - %s", error->message);
+			g_warning ("Error in dbus - %s", error->message);
 			g_error_free (error);
+			goto err;
 		}
 
 		return FALSE;
 	}
-	else {
-		return up_client_get_lid_is_closed (button->priv->client);
-	}
+
+err: /* fall back on our client in case of error */
+	return up_client_get_lid_is_closed (button->priv->client);
 }
 
 /**

--- a/src/gpm-button.c
+++ b/src/gpm-button.c
@@ -284,6 +284,7 @@ gpm_button_is_lid_closed (GpmButton *button)
 					      NULL,
 					      &error
 					      );
+		g_object_unref(proxy);
 		if (error == NULL && res != NULL) {
 			g_variant_get(res, "(v)", &inner );
 			lid = g_variant_get_boolean(inner);
@@ -294,7 +295,6 @@ gpm_button_is_lid_closed (GpmButton *button)
 			g_error ("Error in dbus - %s", error->message);
 			g_error_free (error);
 		}
-		g_object_unref(proxy);
 
 		return FALSE;
 	}

--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -1751,7 +1751,7 @@ gpm_manager_systemd_inhibit (GDBusProxy *proxy) {
                                         &error );
     //append all our arguments
     if (proxy == NULL) {
-        g_error ("Error connecting to dbus - %s", error->message);
+        g_warning ("Error connecting to dbus - %s", error->message);
         g_error_free (error);
         return -1;
     }
@@ -1770,7 +1770,7 @@ gpm_manager_systemd_inhibit (GDBusProxy *proxy) {
                             &error
                             );
     if (error != NULL) {
-        g_error ("Error in dbus - %s", error->message);
+        g_warning ("Error in dbus - %s", error->message);
         g_error_free (error);
         return -EIO;
     }


### PR DESCRIPTION
No need to exit the whole MPM process if a module encounters a failure; otherwise the whole thing goes down.

Fixes #400.

:warning: **WARNING** :warning: I didn't actually test any of this for the moment, because my setup is currently wonky for this; but it should be fairly straightforward anyhow (despite the fact that not erroring-out could have consequences, I don't think it's the case here given what I've seen).