### PR TITLE
Brightness fixes

### DIFF
--- a/data/org.mate.power-manager.gschema.xml.in
+++ b/data/org.mate.power-manager.gschema.xml.in
@@ -61,6 +61,11 @@
       <summary>Reduce the backlight brightness when on battery power</summary>
       <description>If the screen should be reduced in brightness when the computer is on battery power.</description>
     </key>
+    <key name="kbd-backlight-enable" type="b">
+      <default>true</default>
+      <summary>Allow keyboard backlight brightness adjustment</summary>
+      <description>If the keyboard backlight brightness should be switched automatically.</description>
+    </key>
     <key name="kbd-backlight-battery-reduce" type="b">
       <default>true</default>
       <summary>Reduce the keyboard backlight when on battery power</summary>

--- a/src/gpm-backlight.c
+++ b/src/gpm-backlight.c
@@ -426,9 +426,14 @@ gpm_backlight_save_settings (GpmBacklight *backlight, guint percentage)
 		 * running on AC.
 		 */
 		brightness_ac = g_settings_get_double (backlight->priv->settings, GPM_SETTINGS_BRIGHTNESS_AC);
-		battery_reduce = 100 - (gint) (percentage * 100.0f / brightness_ac);
+		if (brightness_ac) {
+			battery_reduce = 100 - (gint) (percentage * 100.0f / brightness_ac);
+		} else {
+			/* Any negative number indicates we surpassed brightness_ac. 0 indicates nothing changed. */
+			battery_reduce = - (gint) percentage;
+		}
 		if (battery_reduce < 0) {
-			/* Brightness set higher than brightness-ac - we have to adjust that value. */
+			/* Brightness set higher than brightness_ac - we have to adjust that value. */
 			g_settings_set_double (backlight->priv->settings, GPM_SETTINGS_BRIGHTNESS_AC,
 					percentage * 1.0);
 			battery_reduce = 0;

--- a/src/gpm-common.h
+++ b/src/gpm-common.h
@@ -68,6 +68,7 @@ G_BEGIN_DECLS
 #define GPM_SETTINGS_BRIGHTNESS_DIM_BATT		"brightness-dim-battery"
 
 /* keyboard backlight */
+#define GPM_SETTINGS_KBD_BACKLIGHT_ENABLE		"kbd-backlight-enable"
 #define GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE     "kbd-backlight-battery-reduce"
 #define GPM_SETTINGS_KBD_BRIGHTNESS_ON_AC      "kbd-brightness-on-ac"
 #define GPM_SETTINGS_KBD_BRIGHTNESS_DIM_BY_ON_BATT      "kbd-brightness-dim-by-on-battery"

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -384,8 +384,8 @@ gpm_kbd_backlight_evaluate_power_source_and_set (GpmKbdBacklight *backlight)
    guint dim_by = 0;
 
    if (g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_ENABLE) == FALSE) {
-      g_warning ("policy is no dimming");
-      return FALSE;
+      g_debug ("policy is no dimming");
+      return TRUE;
    }
 
    if (up_client_get_on_battery (backlight->priv->client) &&

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -440,18 +440,8 @@ gpm_kbd_backlight_button_pressed_cb (GpmButton *button,
                     const gchar *type,
                     GpmKbdBacklight *backlight)
 {
-   static guint saved_brightness = ~0u;
+   static guint saved_brightness;
    gboolean ret;
-
-   if (saved_brightness == ~0u) {
-       saved_brightness = backlight->priv->brightness_percent;
-       /* If the initial value is 0, which probably means we saved on_ac=0, we
-        * try and restore some arbitrary value for the toggle not to seem
-        * broken */
-       if (saved_brightness == 0) {
-           saved_brightness = 100u;
-       }
-   }
 
    if (g_strcmp0 (type, GPM_BUTTON_KBD_BRIGHT_UP) == 0) {
        ret = gpm_kbd_backlight_brightness_up (backlight);
@@ -475,7 +465,13 @@ gpm_kbd_backlight_button_pressed_cb (GpmButton *button,
 
    } else if (g_strcmp0 (type, GPM_BUTTON_KBD_BRIGHT_TOGGLE) == 0) {
        if (backlight->priv->brightness_percent == 0) {
-           /* backlight is off turn it back on */
+           /* backlight is off turn it back on.
+            * If the initial value is 0, which probably means we saved on_ac=0, we
+            * try and restore some arbitrary value for the toggle not to seem
+            * broken. */
+           if (saved_brightness == 0) {
+               saved_brightness = 100u;
+           }
            gpm_kbd_backlight_set (backlight, saved_brightness, TRUE);
        } else {
            /* backlight is on, turn it off and save current value */

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -383,6 +383,11 @@ gpm_kbd_backlight_evaluate_power_source_and_set (GpmKbdBacklight *backlight)
    guint value;
    guint dim_by = 0;
 
+   if (g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_ENABLE) == FALSE) {
+      g_warning ("policy is no dimming");
+      return FALSE;
+   }
+
    if (up_client_get_on_battery (backlight->priv->client) &&
        g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)) {
       dim_by = g_settings_get_int (backlight->priv->settings, GPM_SETTINGS_KBD_BRIGHTNESS_DIM_BY_ON_BATT);


### PR DESCRIPTION
Fix a simple bug in KBD backlight toggle key handling and add some functionality to make KBD and LCD backlight control behave a bit more sane.
Fixes #187 as LCD brightness changes by function keys in battery mode are saved to config now.
It does not fix the problems with keyboard backlight described there, as I found this is a completely different issue. For example on my lenovo laptop, changing keyboard backlight by Fn+Space does not generate a scancode, thus GPM can't keep track of changes made to keyboard backlight. One might come up with some trickery to take such untracked changes in hardware into account, but I found a quick fix that adds a switch to completely disable KBD brightness control in dconf more useful for now.