### PR TITLE
Keyboard backlight handling improvements

### DIFF
--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -416,10 +416,11 @@ gpm_kbd_backlight_button_pressed_cb (GpmButton *button,
                     const gchar *type,
                     GpmKbdBacklight *backlight)
 {
-   static guint saved_brightness;
+   static guint saved_brightness = ~0u;
    gboolean ret;
 
-   saved_brightness = backlight->priv->master_percentage;
+   if (saved_brightness == ~0u)
+       saved_brightness = backlight->priv->master_percentage;
 
    if (g_strcmp0 (type, GPM_BUTTON_KBD_BRIGHT_UP) == 0) {
        ret = gpm_kbd_backlight_brightness_up (backlight);

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -359,22 +359,12 @@ gpm_kbd_backlight_evaluate_power_source_and_set (GpmKbdBacklight *backlight)
 {
    gfloat brightness;
    gfloat scale;
-   gboolean on_battery;
-   gboolean battery_reduce;
    guint value;
-   gboolean ret;
 
    brightness = backlight->priv->master_percentage;
 
-   g_object_get (backlight->priv->client,
-             "on-battery",
-             &on_battery,
-             NULL);
-
-   battery_reduce = g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE);
-
-   if (on_battery) {
-      if (battery_reduce) {
+   if (up_client_get_on_battery (backlight->priv->client)) {
+      if (g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)) {
          value = g_settings_get_int (backlight->priv->settings, GPM_SETTINGS_KBD_BRIGHTNESS_DIM_BY_ON_BATT);
 
          if (value > 100) {
@@ -396,8 +386,7 @@ gpm_kbd_backlight_evaluate_power_source_and_set (GpmKbdBacklight *backlight)
        value = g_settings_get_int (backlight->priv->settings, GPM_SETTINGS_KBD_BRIGHTNESS_ON_AC);
    }
 
-   ret = gpm_kbd_backlight_set (backlight, value, FALSE);
-   return ret;
+   return gpm_kbd_backlight_set (backlight, value, FALSE);
 }
 
 /**
@@ -509,23 +498,14 @@ gpm_kbd_backlight_idle_changed_cb (GpmIdle *idle,
    gfloat brightness;
    gfloat scale;
    guint value;
-   gboolean lid_closed;
-   gboolean on_battery;
    gboolean enable_action;
 
    g_debug("Idle changed");
 
-   lid_closed = gpm_button_is_lid_closed (backlight->priv->button);
-
-   if (lid_closed)
+   if (gpm_button_is_lid_closed (backlight->priv->button))
        return;
 
-   g_object_get (backlight->priv->client,
-                 "on-battery",
-                 &on_battery,
-                 NULL);
-
-   enable_action = on_battery
+   enable_action = up_client_get_on_battery (backlight->priv->client)
        ? g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_IDLE_DIM_BATT)
          && g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)
        : g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_IDLE_DIM_AC);

--- a/src/gpm-kbd-backlight.c
+++ b/src/gpm-kbd-backlight.c
@@ -383,13 +383,9 @@ gpm_kbd_backlight_evaluate_power_source_and_set (GpmKbdBacklight *backlight)
    guint value;
    guint dim_by = 0;
 
-   if (up_client_get_on_battery (backlight->priv->client)) {
-      if (g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)) {
-         dim_by = g_settings_get_int (backlight->priv->settings, GPM_SETTINGS_KBD_BRIGHTNESS_DIM_BY_ON_BATT);
-      } else {
-         // do not change keyboard backlight
-         return TRUE;
-      }
+   if (up_client_get_on_battery (backlight->priv->client) &&
+       g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)) {
+      dim_by = g_settings_get_int (backlight->priv->settings, GPM_SETTINGS_KBD_BRIGHTNESS_DIM_BY_ON_BATT);
    }
 
    value = gpm_kbd_backlight_get_ac_percentage_dimmed (backlight, dim_by);
@@ -428,7 +424,9 @@ gpm_kbd_backlight_client_changed_cb (UpClient *client,
                                      GParamSpec *pspec,
                                      GpmKbdBacklight *backlight)
 {
-   gpm_kbd_backlight_evaluate_power_source_and_set (backlight);
+   if (g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)) {
+      gpm_kbd_backlight_evaluate_power_source_and_set (backlight);
+   }
 }
 
 /**
@@ -513,7 +511,6 @@ gpm_kbd_backlight_idle_changed_cb (GpmIdle *idle,
 
    enable_action = up_client_get_on_battery (backlight->priv->client)
        ? g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_IDLE_DIM_BATT)
-         && g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_KBD_BACKLIGHT_BATT_REDUCE)
        : g_settings_get_boolean (backlight->priv->settings, GPM_SETTINGS_IDLE_DIM_AC);
 
    if (!enable_action)


### PR DESCRIPTION
See commit log, but most important bits:
* [**Fix toggling backlight back on**](https://github.com/mate-desktop/mate-power-manager/commit/1def59bb169006897048b8de351e1ddd1bba4441).  When triggering the toggle action, without this it turns off just fine, but never comes back: one has to use the up action enough times to get back the previous brightness.  This was a simple one.
* [**Persistently save user-set brightness**](https://github.com/mate-desktop/mate-power-manager/commit/4d725c390cd5f7f19d2aea8c7cddf88c89b51cc4).  Currently the brightness was never saved, so one would have had to manually change the "brightness on AC" value to restore a desired value.  This seems overly annoying when having up/down/toggle keyboard buttons that the values they set is not remembered.  So, I changed this so that user actions (e.g. button triggers) modify the saved value, and is used to restore next time the daemon starts.

The rest is cleanups, and [a small change to the handling of some settings combinations](https://github.com/mate-desktop/mate-power-manager/commit/80466432a003431c6c8319a3ad90a52b765fc082) because they were just odd in some corner cases, and mostly irrelevant now the user changes are preserved.

---

I *guess* that not many people use keyboard backlight under MATE, because it seems really under-loved and especially the toggle bug seems both annoying and simple enough that it would have been spotted and fixed before.  I myself just got my hands on a laptop with keyboard backlight with a proper Linux driver for controlling it requiring no hacks, and I couldn't help myself but to fix this :slightly_smiling_face: 
Hopefully I can still get some review on this, or just rely on street cred :v: 