### PR TITLE
ci: fix travis build failures caused by recent travis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_install:
   - chmod +x docker-build gen-index
 
 install:
-  - pip3 install PyGithub
+  - sudo apt-get install -y python3-pip python3-setuptools
+  - sudo pip3 install --upgrade pip
+  - sudo pip3 install PyGithub
   - ./docker-build --name ${DISTRO} --config .build.yml --install
 
 script:
@@ -38,9 +40,17 @@ notifications:
     on_success: never
     on_failure: always
 
+before_deploy:
+  - yes | gem update --system --force
+  - gem install bundler
+  - gem install faraday-net_http -v '3.3.0' # Avoid faraday version problem
+  - gem install uri
+  - gem install logger
+
 deploy:
   - provider: pages
-    edge: true
+    edge:
+      branch: v2.0.5
     token: $GITHUB_TOKEN
     keep_history: false
     committer_from_gh: true
@@ -51,7 +61,8 @@ deploy:
       all_branches: true
       condition: ${DISTRO} =~ ^fedora.*$
   - provider: script
-    edge: true
+    edge:
+      branch: v2.0.5
     script: ./docker-build --verbose --config .build.yml --release github
     on:
       tags: true


### PR DESCRIPTION
This just imports https://github.com/mate-desktop/atril/pull/619 to this repository, which fixes the issue here as well (see https://github.com/mate-desktop/mate-power-manager/pull/404)