### PR TITLE
applets: Fix automake build errors with in-process applets

### DIFF
--- a/applets/brightness/Makefile.am
+++ b/applets/brightness/Makefile.am
@@ -33,6 +33,7 @@ libmate_brightness_applet_la_SOURCES =				\
 	brightness-applet.c					\
 	gpm-common.c						\
 	gpm-common.h
+libmate_brightness_applet_la_CFLAGS = $(AM_CFLAGS)
 libmate_brightness_applet_la_LDFLAGS = -module -avoid-version
 libmate_brightness_applet_la_LIBADD =				\
 	$(DBUS_LIBS)						\
@@ -47,6 +48,7 @@ mate_brightness_applet_SOURCES =				\
 	brightness-applet.c					\
 	gpm-common.c						\
 	gpm-common.h
+mate_brightness_applet_CFLAGS = $(AM_CFLAGS)
 mate_brightness_applet_LDADD =					\
 	$(DBUS_LIBS)						\
 	$(CAIRO_LIBS)						\

--- a/applets/inhibit/Makefile.am
+++ b/applets/inhibit/Makefile.am
@@ -33,6 +33,7 @@ libmate_inhibit_applet_la_SOURCES =				\
 	inhibit-applet.c					\
 	gpm-common.c						\
 	gpm-common.h
+libmate_inhibit_applet_la_CFLAGS = $(AM_CFLAGS)
 libmate_inhibit_applet_la_LDFLAGS = -module -avoid-version
 libmate_inhibit_applet_la_LIBADD =				\
 	$(DBUS_LIBS)						\
@@ -47,6 +48,7 @@ mate_inhibit_applet_SOURCES =					\
 	inhibit-applet.c					\
 	gpm-common.c						\
 	gpm-common.h
+mate_inhibit_applet_CFLAGS = $(AM_CFLAGS)
 mate_inhibit_applet_LDADD =					\
 	$(DBUS_LIBS)						\
 	$(CAIRO_LIBS)						\

--- a/applets/power-profiles/Makefile.am
+++ b/applets/power-profiles/Makefile.am
@@ -33,6 +33,7 @@ libmate_power_profiles_applet_la_SOURCES =			\
 	power-profiles-applet.c					\
 	gpm-common.c						\
 	gpm-common.h
+libmate_power_profiles_applet_la_CFLAGS = $(AM_CFLAGS)
 libmate_power_profiles_applet_la_LDFLAGS = -module -avoid-version
 libmate_power_profiles_applet_la_LIBADD =			\
 	$(DBUS_LIBS)						\
@@ -47,6 +48,7 @@ mate_power_profiles_applet_SOURCES =				\
 	power-profiles-applet.c					\
 	gpm-common.c						\
 	gpm-common.h
+mate_power_profiles_applet_CFLAGS = $(AM_CFLAGS)
 mate_power_profiles_applet_LDADD =				\
 	$(DBUS_LIBS)						\
 	$(CAIRO_LIBS)						\


### PR DESCRIPTION
Add per-target CFLAGS variables to applet Makefiles to fix build errors when objects are created with and without libtool.

Fixes #416