### PR TITLE
gpm-manager: Remove unsupported markup

### DIFF
--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -1596,7 +1596,7 @@ gpm_manager_engine_charge_action_cb (GpmEngine *engine, UpDevice *device, GpmMan
 		} else if (policy == GPM_ACTION_POLICY_SUSPEND) {
 			/* TRANSLATORS: computer will suspend */
 			message = g_strdup (_("The battery is below the critical level and "
-					      "this computer is about to suspend.<br>"
+					      "this computer is about to suspend.\n"
 					      "<b>NOTE:</b> A small amount of power is required "
 					      "to keep your computer in a suspended state."));
 


### PR DESCRIPTION
The notification spec only supports a handful of tags and `<br>` is not one of them.

Fixes #272

<img width="480" alt="Screenshot at 2026-06-17 15-10-48" src="https://github.com/user-attachments/assets/50249275-f201-43ed-832b-aa5f12d78504" />